### PR TITLE
Update .list-standout to preserve line height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,11 +48,7 @@ Temporary Items
 SyncToy_dc7c780e-a1a5-4cf2-8ef3-b035c84cecbe.dat
 
 
-#add 'node_modules' to .gitignore file
-
-git rm -r --cached node_modules
-git commit -m 'Remove the now ignored directory node_modules'
-git push origin master
+# Folders created by npm and Visual Studio
 /node_modules
 /.vs
 *.dat

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,8 +85,7 @@ module.exports = function (grunt) {
             },
             options: {
                 // the banner is inserted at the top of the output
-                banner: '/* <%= pkg.name %> - v<%= pkg.version %> - <%= grunt.template.today("mmm-dd-yyyy' +
-                    '") %> */\n/* JS COMPILED FROM SOURCE DO NOT MODIFY */\n'
+                banner: '/* <%= pkg.name %> - v<%= pkg.version %> */\n/* JS COMPILED FROM SOURCE DO NOT MODIFY */\n'
             }
         },
 
@@ -96,8 +95,7 @@ module.exports = function (grunt) {
                     paths: ["css"],
                     compress: false,
                     ieCompat: true,
-                    banner: '/* <%= pkg.name %> - v<%= pkg.version %> - <%= grunt.template.today("mmm-dd-yyyy' +
-                        '") %> */\n/* STYLES COMPILED FROM SOURCE (LESS) DO NOT MODIFY */\n\n'
+                    banner: '/* <%= pkg.name %> - v<%= pkg.version %> */\n/* STYLES COMPILED FROM SOURCE (LESS) DO NOT MODIFY */\n\n'
                 },
                 files: csssrc
             },
@@ -106,8 +104,7 @@ module.exports = function (grunt) {
                     paths: ["css"],
                     compress: true,
                     ieCompat: true,
-                    banner: '/* <%= pkg.name %> - v<%= pkg.version %> - <%= grunt.template.today("mmm-dd-yyyy' +
-                        '") %> */\n/* STYLES COMPILED FROM SOURCE (LESS) DO NOT MODIFY */\n\n'
+                    banner: '/* <%= pkg.name %> - v<%= pkg.version %> */\n/* STYLES COMPILED FROM SOURCE (LESS) DO NOT MODIFY */\n\n'
                 },
                 files: csssrc
             }

--- a/css/cagov.core.css
+++ b/css/cagov.core.css
@@ -11770,16 +11770,17 @@ ul.list-overstated a {
 }
 .list-standout li {
   padding-left: 1.5em;
+  position: relative;
 }
 .list-standout li:before {
   content: "\35";
   font-family: "CaGov";
   width: 1.5em;
-  margin-left: -1.5em;
-  vertical-align: sub;
   font-size: 1.5em;
   font-weight: 900;
-  display: inline-block;
+  position: absolute;
+  left: 0;
+  top: -.22em;
 }
 .list-standout li.open:before {
   content: "\33";

--- a/css/cagov.core.css
+++ b/css/cagov.core.css
@@ -1,4 +1,4 @@
-/* cagov-template-v5 - v0.0.1 - Nov-22-2017 */
+/* cagov-template-v5 - v0.0.1 */
 /* STYLES COMPILED FROM SOURCE (LESS) DO NOT MODIFY */
 /* -----------------------------------------
    NORMALIZE - /source/less/bootstrap/normalize.less
@@ -92,7 +92,6 @@ figure {
   margin: 1em 40px;
 }
 hr {
-  -moz-box-sizing: content-box;
   box-sizing: content-box;
   height: 0;
 }
@@ -152,8 +151,6 @@ input[type="number"]::-webkit-outer-spin-button {
 }
 input[type="search"] {
   -webkit-appearance: textfield;
-  -moz-box-sizing: content-box;
-  -webkit-box-sizing: content-box;
   box-sizing: content-box;
 }
 input[type="search"]::-webkit-search-cancel-button,
@@ -187,14 +184,10 @@ th {
    SCAFFOLDING - /source/less/bootstrap/scaffolding.less
 ----------------------------------------- */
 * {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 *:before,
 *:after {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 html {
@@ -253,8 +246,6 @@ img {
   background-color: #fff;
   border: 1px solid #ddd;
   border-radius: 0;
-  -o-transition: all 0.2s ease-in-out;
-  -webkit-transition: all 0.2s ease-in-out;
   transition: all 0.2s ease-in-out;
   display: inline-block;
   width: 100% \9;
@@ -1637,8 +1628,6 @@ label {
   font-weight: bold;
 }
 input[type="search"] {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 input[type="radio"],
@@ -1684,16 +1673,12 @@ output {
   background-image: none;
   border: 1px solid #ccc;
   border-radius: 0;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-  -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
-  -webkit-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
   transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
 }
 .form-control:focus {
   border-color: #66afe9;
   outline: 0;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(102, 175, 233, 0.6);
 }
 .form-control::-moz-placeholder {
@@ -1881,12 +1866,10 @@ select[multiple].input-lg {
 }
 .has-success .form-control {
   border-color: #72ce6f;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
 .has-success .form-control:focus {
   border-color: #4dc149;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #bde8bb;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #bde8bb;
 }
 .has-success .input-group-addon {
@@ -1907,12 +1890,10 @@ select[multiple].input-lg {
 }
 .has-warning .form-control {
   border-color: #8a6d3b;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
 .has-warning .form-control:focus {
   border-color: #66512c;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
 }
 .has-warning .input-group-addon {
@@ -1933,12 +1914,10 @@ select[multiple].input-lg {
 }
 .has-error .form-control {
   border-color: #d34a37;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
 }
 .has-error .form-control:focus {
   border-color: #b03827;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #e5968b;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #e5968b;
 }
 .has-error .input-group-addon {
@@ -2086,7 +2065,6 @@ select[multiple].input-lg {
 .btn.active {
   outline: 0;
   background-image: none;
-  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
 .btn.disabled,
@@ -2095,7 +2073,6 @@ fieldset[disabled] .btn {
   cursor: not-allowed;
   opacity: 0.35;
   filter: alpha(opacity=35);
-  -webkit-box-shadow: none;
   box-shadow: none;
 }
 a.btn.disabled,
@@ -2359,7 +2336,6 @@ fieldset[disabled] .btn-danger.active {
 .btn-link[disabled],
 fieldset[disabled] .btn-link {
   background-color: transparent;
-  -webkit-box-shadow: none;
   box-shadow: none;
 }
 .btn-link,
@@ -2419,8 +2395,6 @@ input[type="button"].btn-block {
 ----------------------------------------- */
 .fade {
   opacity: 0;
-  -o-transition: opacity 0.15s linear;
-  -webkit-transition: opacity 0.15s linear;
   transition: opacity 0.15s linear;
 }
 .fade.in {
@@ -2442,8 +2416,6 @@ tbody.collapse.in {
   position: relative;
   height: 0;
   overflow: hidden;
-  -o-transition: height 0.35s ease;
-  -webkit-transition: height 0.35s ease;
   transition: height 0.35s ease;
 }
 /* -----------------------------------------
@@ -2482,7 +2454,6 @@ tbody.collapse.in {
   border: 1px solid #ccc;
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 0;
-  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   background-clip: padding-box;
 }
@@ -2677,11 +2648,9 @@ tbody.collapse.in {
   padding-right: 12px;
 }
 .btn-group.open .dropdown-toggle {
-  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
 .btn-group.open .dropdown-toggle.btn-link {
-  -webkit-box-shadow: none;
   box-shadow: none;
 }
 .btn .caret {
@@ -3298,7 +3267,6 @@ a.label:focus {
   margin-bottom: 22px;
   background-color: #f5f5f5;
   border-radius: 0;
-  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 .progress-bar {
@@ -3310,23 +3278,17 @@ a.label:focus {
   color: #fff;
   text-align: center;
   background-color: #046B99;
-  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
   box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
-  -o-transition: width 0.6s ease;
-  -webkit-transition: width 0.6s ease;
   transition: width 0.6s ease;
 }
 .progress-striped .progress-bar,
 .progress-bar-striped {
-  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-size: 40px 40px;
 }
 .progress.active .progress-bar,
 .progress-bar.active {
   -webkit-animation: progress-bar-stripes 2s linear infinite;
-  -o-animation: progress-bar-stripes 2s linear infinite;
   animation: progress-bar-stripes 2s linear infinite;
 }
 .progress-bar[aria-valuenow="1"],
@@ -3344,32 +3306,24 @@ a.label:focus {
   background-color: #72ce6f;
 }
 .progress-striped .progress-bar-success {
-  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
 .progress-bar-info {
   background-color: #1C7DB5;
 }
 .progress-striped .progress-bar-info {
-  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
 .progress-bar-warning {
   background-color: #F27e31;
 }
 .progress-striped .progress-bar-warning {
-  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
 .progress-bar-danger {
   background-color: #d34a37;
 }
 .progress-striped .progress-bar-danger {
-  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
   background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
 }
 /* -----------------------------------------
@@ -3431,7 +3385,6 @@ a.label:focus {
   background-color: #fff;
   border: 1px solid transparent;
   border-radius: 0;
-  -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
   box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
 }
 .panel-body {
@@ -3783,9 +3736,7 @@ button.close {
 .modal.fade .modal-dialog {
   -webkit-transform: translate3d(0, -25%, 0);
   transform: translate3d(0, -25%, 0);
-  -webkit-transition: -webkit-transform 0.3s ease-out;
-  -moz-transition: -moz-transform 0.3s ease-out;
-  -o-transition: -o-transform 0.3s ease-out;
+  transition: -webkit-transform 0.3s ease-out;
   transition: transform 0.3s ease-out;
 }
 .modal.in .modal-dialog {
@@ -3807,7 +3758,6 @@ button.close {
   border: 1px solid #999;
   border: 1px solid rgba(0, 0, 0, 0.2);
   border-radius: 6px;
-  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
   box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
   background-clip: padding-box;
   outline: 0;
@@ -3873,7 +3823,6 @@ button.close {
     margin: 30px auto;
   }
   .modal-content {
-    -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
   }
   .modal-sm {
@@ -4342,8 +4291,6 @@ a:focus {
   position: absolute;
   top: -999999em;
   display: block;
-  -o-transition: 0.6s, ease-in-out, left;
-  -webkit-transition: 0.6s, ease-in-out, left;
   transition: 0.6s, ease-in-out, left;
 }
 .carousel-inner > .active {
@@ -5109,7 +5056,6 @@ html {
    TYPE STYLES - /source/less/cagov/type.less
 ----------------------------------------- */
 body {
-  -webkit-transition: font-size 0.25s ease-in;
   transition: font-size 0.25s ease-in;
 }
 .featured-narrative {
@@ -5395,7 +5341,6 @@ h6,
   top: 50% !important;
   left: 50% !important;
   -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
   -webkit-backface-visibility: hidden;
 }
@@ -5403,7 +5348,6 @@ h6,
   position: relative;
   left: 50% !important;
   -webkit-transform: translateX(-50%);
-  -ms-transform: translateX(-50%);
   transform: translateX(-50%);
   -webkit-backface-visibility: hidden;
 }
@@ -5411,7 +5355,6 @@ h6,
   position: relative;
   top: 50% !important;
   -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
   transform: translateY(-50%);
   -webkit-backface-visibility: hidden;
 }
@@ -5421,7 +5364,6 @@ h6,
   top: 50% !important;
   left: 50% !important;
   -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
   -webkit-backface-visibility: hidden;
 }
@@ -5429,7 +5371,6 @@ h6,
   position: absolute !important;
   left: 50% !important;
   -webkit-transform: translateX(-50%);
-  -ms-transform: translateX(-50%);
   transform: translateX(-50%);
   -webkit-backface-visibility: hidden;
 }
@@ -5437,7 +5378,6 @@ h6,
   position: absolute !important;
   top: 50% !important;
   -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
   transform: translateY(-50%);
   -webkit-backface-visibility: hidden;
 }
@@ -5447,6 +5387,8 @@ h6,
 .group {
   margin-left: -15px;
   margin-right: -15px;
+}
+@media (max-width: 767px) {
 }
 .full-width {
   position: relative;
@@ -5612,7 +5554,6 @@ h6,
 }
 .branding .header-organization-banner {
   line-height: 88px;
-  -webkit-transition: all 0.3s;
   transition: all 0.3s;
 }
 .branding .header-organization-banner img {
@@ -5761,7 +5702,6 @@ h6,
   #head-search.fixed-hide:not(.active) {
     visibility: hidden;
     opacity: 0;
-    -webkit-transition: all 0.3s;
     transition: all 0.3s;
   }
   .no-js .ask-group.fade {
@@ -5853,7 +5793,6 @@ h6,
 .global-footer a:not(.btn) {
   color: #f5f5f5;
   text-decoration: none;
-  -webkit-transition: all 0.25s;
   transition: all 0.25s;
 }
 .global-footer a:not(.btn):hover,
@@ -5948,7 +5887,6 @@ h6,
   width: 100%;
   max-height: 0;
   border: none;
-  -webkit-transition: all 0.5s 0.1s;
   transition: all 0.5s 0.1s;
 }
 @media (min-width: 768px) {
@@ -5989,7 +5927,6 @@ h6,
   border-radius: 0;
   border: 3px solid transparent;
   padding: 0 10px;
-  -webkit-transition: border 0.4s;
   transition: border 0.4s;
   outline: none;
 }
@@ -5998,7 +5935,6 @@ h6,
   float: left;
   height: auto;
   height: 40px;
-  -webkit-transition: all 0.5s 0.1s;
   transition: all 0.5s 0.1s;
 }
 .search-container .submit-container:before,
@@ -6026,7 +5962,6 @@ h6,
 .search-container .submit-container button,
 .featured-search.active .submit-container button {
   float: left;
-  -webkit-transition: all 0.5s 0.1s;
   transition: all 0.5s 0.1s;
   background: none;
   border-color: white;
@@ -6143,7 +6078,6 @@ h6,
     min-height: 75px;
     width: 60%;
     left: 20%;
-    -webkit-transition: all 0.4s;
     transition: all 0.4s;
   }
   .flexbox .featured-search {
@@ -6170,11 +6104,9 @@ h6,
   .featured-search .submit-container {
     height: 55px;
     width: 55px;
-    -webkit-transition: all 0.4s;
     transition: all 0.4s;
   }
   .featured-search .submit-container button {
-    -webkit-transition: all 0.4s;
     transition: all 0.4s;
     font-size: 40px;
     font-size: 2.5rem;
@@ -6189,7 +6121,6 @@ h6,
     position: relative;
     visibility: visible;
     opacity: 1;
-    -webkit-transition: top 0.4s, left 0.2s 0.4s, width 0.2s 0.4s, background-color 0.6s, border 0.4s, padding 0.2s 0.4s;
     transition: top 0.4s, left 0.2s 0.4s, width 0.2s 0.4s, background-color 0.6s, border 0.4s, padding 0.2s 0.4s;
     top: 96px;
     left: 0;
@@ -6212,7 +6143,6 @@ h6,
     border-radius: 0;
     border: 3px solid transparent;
     padding: 0 4px;
-    -webkit-transition: border 0.4s;
     transition: border 0.4s;
     outline: none;
   }
@@ -6521,7 +6451,6 @@ GOOGLE CUSTOM SEARCH CUSTOMIZATION OVERRIDES beta 5.0 addition
   z-index: 5;
   top: 0;
   visibility: collapse;
-  -webkit-transition: opacity .5s .7s;
   transition: opacity .5s .7s;
   opacity: 0;
 }
@@ -6629,7 +6558,6 @@ GOOGLE CUSTOM SEARCH CUSTOMIZATION OVERRIDES beta 5.0 addition
   list-style: none;
   margin: 0;
   padding: 0;
-  -webkit-transition: .3s;
   transition: all .3s;
 }
 .top-level-nav .nav-item {
@@ -6691,9 +6619,7 @@ GOOGLE CUSTOM SEARCH CUSTOMIZATION OVERRIDES beta 5.0 addition
     display: table;
     table-layout: auto;
     display: -webkit-box;
-    display: -moz-box;
     display: -ms-flexbox;
-    display: -webkit-flex;
     display: flex;
     width: 100%;
     min-height: 91px;
@@ -6706,8 +6632,6 @@ GOOGLE CUSTOM SEARCH CUSTOMIZATION OVERRIDES beta 5.0 addition
     display: table-cell;
     display: block;
     -webkit-box-flex: 1;
-    -moz-box-flex: 1;
-    -webkit-flex: 1 1 auto;
     -ms-flex: 1 1 auto;
     flex: 1 1 auto;
   }
@@ -6821,9 +6745,6 @@ GOOGLE CUSTOM SEARCH CUSTOMIZATION OVERRIDES beta 5.0 addition
     height: 100%;
     left: 0;
     margin-left: 0;
-    -webkit-transition: margin-left 0.5s ease;
-    -moz-transition: margin-left 0.5s ease;
-    -o-transition: margin-left 0.5s ease;
     transition: margin-left 0.5s ease;
   }
   .oc-menu-open .oc-inner {
@@ -6834,7 +6755,6 @@ GOOGLE CUSTOM SEARCH CUSTOMIZATION OVERRIDES beta 5.0 addition
     width: 70%;
     left: -70%;
     top: 0;
-    -webkit-transition: left 0.5s ease;
     transition: left 0.5s ease;
     overflow-y: auto;
     overflow-x: hidden;
@@ -6849,8 +6769,6 @@ GOOGLE CUSTOM SEARCH CUSTOMIZATION OVERRIDES beta 5.0 addition
     height: auto;
     width: 100%;
     background: none;
-    -webkit-box-shadow: -6px -1px 30px 0px rgba(5, 5, 5, 0.5);
-    -moz-box-shadow: -6px -1px 30px 0px rgba(5, 5, 5, 0.5);
     box-shadow: -6px -1px 30px 0px rgba(5, 5, 5, 0.5);
     cursor: alias;
   }
@@ -7098,8 +7016,12 @@ a.second-level-link [class^="ca-gov-icon-"] {
     -moz-column-gap: 20px;
     -ms-column-gap: 20px;
     -webkit-column-gap: 20px;
-    column-count: 3;
-    column-gap: 20px;
+    -webkit-column-count: 3;
+       -moz-column-count: 3;
+            column-count: 3;
+    -webkit-column-gap: 20px;
+       -moz-column-gap: 20px;
+            column-gap: 20px;
   }
   .main-navigation.megadropdown.original .sub-nav {
     padding: 16px;
@@ -7127,8 +7049,12 @@ a.second-level-link [class^="ca-gov-icon-"] {
     -moz-column-gap: 20px;
     -ms-column-gap: 20px;
     -webkit-column-gap: 20px;
-    column-count: 1;
-    column-gap: 20px;
+    -webkit-column-count: 1;
+       -moz-column-count: 1;
+            column-count: 1;
+    -webkit-column-gap: 20px;
+       -moz-column-gap: 20px;
+            column-gap: 20px;
   }
   .main-navigation.megadropdown.original .sub-nav[class*="with-image-"] > ul > li {
     padding-right: 16px !important;
@@ -7178,11 +7104,13 @@ a.second-level-link [class^="ca-gov-icon-"] {
   break-inside: avoid;
 }
 /* Accessible Menu */
+.main-navigation {
+  transition: all .5s;
+}
 .nav-item {
   display: inline-block;
 }
 .sub-nav {
-  -webkit-transition: all .4s;
   transition: all .4s;
   left: 0;
 }
@@ -7532,7 +7460,6 @@ a.second-level-link [class^="ca-gov-icon-"] {
     position: relative;
     width: 60%;
     left: 20%;
-    -webkit-transition: opacity 0.3s, visibility 0.3s;
     transition: opacity 0.3s, visibility 0.3s;
     z-index: 5;
     visibility: visible;
@@ -7634,6 +7561,8 @@ a.second-level-link [class^="ca-gov-icon-"] {
   background-color: #000;
   background-color: rgba(0, 0, 0, 0.8);
   padding: 5px 10px;
+}
+@media (max-width: 767px) {
 }
 .ask-options > ul {
   padding-left: 0;
@@ -8164,7 +8093,6 @@ body {
 }
 .carousel.owl-grab {
   cursor: move;
-  cursor: -webkit-grab;
   cursor: -o-grab;
   cursor: -ms-grab;
   cursor: grab;
@@ -8184,10 +8112,6 @@ body {
  */
 .carousel .owl-item .owl-lazy {
   opacity: 0;
-  -webkit-transition: opacity 400ms ease;
-  -moz-transition: opacity 400ms ease;
-  -ms-transition: opacity 400ms ease;
-  -o-transition: opacity 400ms ease;
   transition: opacity 400ms ease;
 }
 .carousel .owl-item img {
@@ -8233,10 +8157,6 @@ body {
  * 	Owl Carousel - Auto Height Plugin
  */
 .owl-height {
-  -webkit-transition: height 500ms ease-in-out;
-  -moz-transition: height 500ms ease-in-out;
-  -ms-transition: height 500ms ease-in-out;
-  -o-transition: height 500ms ease-in-out;
   transition: height 500ms ease-in-out;
 }
 /*
@@ -8258,17 +8178,9 @@ body {
   cursor: pointer;
   z-index: 1;
   -webkit-backface-visibility: hidden;
-  -webkit-transition: scale 100ms ease;
-  -moz-transition: scale 100ms ease;
-  -ms-transition: scale 100ms ease;
-  -o-transition: scale 100ms ease;
   transition: scale 100ms ease;
 }
 .owl-carousel .owl-video-play-icon:hover {
-  -webkit-transition: scale(1.3, 1.3);
-  -moz-transition: scale(1.3, 1.3);
-  -ms-transition: scale(1.3, 1.3);
-  -o-transition: scale(1.3, 1.3);
   transition: scale(1.3, 1.3);
 }
 .owl-carousel .owl-video-playing .owl-video-tn,
@@ -8280,14 +8192,7 @@ body {
   height: 100%;
   background-position: center center;
   background-repeat: no-repeat;
-  -webkit-background-size: contain;
-  -moz-background-size: contain;
-  -o-background-size: contain;
   background-size: contain;
-  -webkit-transition: opacity 400ms ease;
-  -moz-transition: opacity 400ms ease;
-  -ms-transition: opacity 400ms ease;
-  -o-transition: opacity 400ms ease;
   transition: opacity 400ms ease;
 }
 .owl-carousel .owl-video-frame {
@@ -8328,16 +8233,12 @@ body {
   background: #f9f9f9;
   color: #444;
   text-shadow: none;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
   border-radius: 4px;
 }
 .fancybox-opened {
   z-index: 8030;
 }
 .fancybox-opened .fancybox-skin {
-  -webkit-box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
-  -moz-box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
 }
 .fancybox-outer,
@@ -8503,8 +8404,6 @@ body {
   background: transparent;
   /* Fallback for web browsers that doesn't support RGBa */
   background: rgba(0, 0, 0, 0.8);
-  -webkit-border-radius: 15px;
-  -moz-border-radius: 15px;
   border-radius: 15px;
   text-shadow: 0 1px 2px #222;
   color: #FFF;
@@ -8837,7 +8736,8 @@ body {
   }
   40%,
   43% {
-    animation-timing-function: cubic-bezier(0.755, 0.05, 0.855, 0.06);
+    -webkit-animation-timing-function: cubic-bezier(0.755, 0.05, 0.855, 0.06);
+            animation-timing-function: cubic-bezier(0.755, 0.05, 0.855, 0.06);
     -webkit-transform: translate3d(0, -30px, 0);
     transform: translate3d(0, -30px, 0);
   }
@@ -9238,7 +9138,6 @@ body {
   -webkit-column-rule: rgba(255, 255, 255, 0.8);
   -moz-column-rule: rgba(255, 255, 255, 0.8);
   column-rule: rgba(255, 255, 255, 0.8);
-  -webkit-transition: all 0.2s;
   transition: all 0.2s;
 }
 .alert-banner .close {
@@ -9813,10 +9712,6 @@ hr.hr-light {
   font-size: 0.9rem;
   margin: 0 30px .2em 0;
   padding: 4px 35px 2px 10px;
-  background: -moz-linear-gradient(left, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0) 100%);
-  background: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0) 100%);
-  background: -o-linear-gradient(left, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0) 100%);
-  background: -ms-linear-gradient(left, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0) 100%);
   background: linear-gradient(to right, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0) 100%);
   filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#20000000', endColorStr='#00000000', GradientType='1');
 }
@@ -10000,7 +9895,6 @@ figcaption {
   position: relative;
   text-align: center;
   background-color: #e8e8e8;
-  -webkit-transition: all 0.2s ease-in-out 0s;
   transition: all 0.2s ease-in-out 0s;
 }
 .news-icon:hover {
@@ -10029,13 +9923,11 @@ figcaption {
 }
 .block-hover:hover .block-hover_zoom {
   -webkit-transform: scale(1.1);
-  -ms-transform: scale(1.1);
   transform: scale(1.1);
 }
 [class*="block-hover"],
 [class*="block-hover"]::before,
 [class*="block-hover"]::after {
-  -webkit-transition: all .3s ease;
   transition: all .3s ease;
 }
 .block-hover_zoom {
@@ -10539,17 +10431,26 @@ figcaption {
   margin: 0 15px;
 }
 .input-group {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   position: relative;
   width: 100%;
 }
 .input-group .form-control {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  -moz-box-flex: 1;
-  -webkit-flex: 1;
-  flex: 1 1 auto;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -webkit-box-flex: 1;
+      -ms-flex: 1 1 auto;
+          flex: 1 1 auto;
 }
 .input-group-addon {
   min-width: 38px;
@@ -10557,8 +10458,9 @@ figcaption {
   border: 1px solid;
   border-color: #ccc;
   transition: border-color 0.15s ease-in-out 0s;
-  -moz-box-align: center;
-  align-items: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   text-align: center;
   vertical-align: middle;
   white-space: nowrap;
@@ -10573,6 +10475,8 @@ figcaption {
   border-left: none;
 }
 .d-flex {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
 }
 d-block {
@@ -10610,11 +10514,13 @@ d-block {
   opacity: 0;
 }
 .check-icon-radio {
-  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
   position: absolute;
   left: 0;
   top: 50%;
-  transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+          transform: translateY(-50%);
   width: 18px;
   height: 18px;
   font-size: 12px;
@@ -10628,12 +10534,12 @@ d-block {
   height: 10px;
   width: 10px;
   display: block;
-  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
   position: absolute;
   top: 50%;
   left: 50%;
   -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
 }
 .check-icon-radio i::before {
@@ -10641,15 +10547,16 @@ d-block {
   left: 50%;
   position: absolute;
   -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
 }
 .check-icon-checkbox {
-  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+          backface-visibility: hidden;
   position: absolute;
   left: 0;
   top: 50%;
-  transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+          transform: translateY(-50%);
   width: 18px;
   height: 18px;
   font-size: 12px;
@@ -10664,7 +10571,6 @@ d-block {
   position: absolute;
   top: 50%;
   -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
   width: 100%;
 }
@@ -10674,7 +10580,6 @@ d-block {
   top: 50%;
   position: absolute;
   -webkit-transform: translate(-50%, -50%);
-  -ms-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
 }
 input[type="checkbox"]:checked + i,
@@ -10940,7 +10845,6 @@ input[type="radio"]:focus + .btn {
   color: #000;
   background-color: rgba(255, 255, 255, 0.65);
   border-color: #000;
-  -webkit-transition: all 0.5s;
   transition: all 0.5s;
   padding: 1px 5px;
   font-size: 14px;
@@ -11073,7 +10977,6 @@ fieldset[disabled] .location.banner .btn.active {
   color: #000;
   background-color: rgba(255, 255, 255, 0.65);
   border-color: #000;
-  -webkit-transition: all 0.5s;
   transition: all 0.5s;
   padding: 1px 5px;
   font-size: 14px;
@@ -11280,7 +11183,6 @@ fieldset[disabled] .location.contact .btn.active {
   z-index: 100;
   height: 100%;
   width: 100%;
-  -webkit-transition: all 0.3s;
   transition: all 0.3s;
 }
 .gallery a.gallery-item:hover:before {
@@ -11299,7 +11201,6 @@ fieldset[disabled] .location.contact .btn.active {
   font-family: 'CaGov';
   font-size: 32px;
   font-size: 2rem;
-  -webkit-transition: all .5s;
   transition: all .5s;
 }
 .gallery a.gallery-item:hover:after {
@@ -11503,7 +11404,6 @@ fieldset[disabled] .location.contact .btn.active {
   transition: all 0.2s ease-in-out;
   color: #fff;
   -webkit-transform: translateY(-51%);
-  -ms-transform: translateY(-51%);
   transform: translateY(-51%);
   font-size: 1.57143rem;
   height: 3.92857rem;
@@ -11521,7 +11421,6 @@ fieldset[disabled] .location.contact .btn.active {
   top: 50%;
   display: block;
   -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
   transform: translateY(-50%);
   z-index: 2;
 }
@@ -12014,7 +11913,6 @@ blockquote {
   color: #fff;
   background-color: #046B99;
   border-color: #046B99;
-  -webkit-transition: all 0.5s;
   transition: all 0.5s;
 }
 .btn-primary:hover,
@@ -12057,7 +11955,6 @@ fieldset[disabled] .btn-primary.active {
   color: #000;
   background-color: rgba(255, 255, 255, 0.65);
   border-color: #000;
-  -webkit-transition: all 0.5s;
   transition: all 0.5s;
 }
 .btn-default:hover,
@@ -12100,7 +11997,6 @@ fieldset[disabled] .btn-default.active {
   color: #fff;
   background-color: #323A45;
   border-color: #323A45;
-  -webkit-transition: all 0.5s;
   transition: all 0.5s;
 }
 .btn-standout:hover,
@@ -12143,7 +12039,6 @@ fieldset[disabled] .btn-standout.active {
   color: #333333;
   background-color: #FDB81E;
   border-color: #FDB81E;
-  -webkit-transition: all 0.5s;
   transition: all 0.5s;
 }
 .btn-highlight:hover,
@@ -12276,7 +12171,6 @@ fieldset[disabled] .btn-secondary.active {
 .btn-more.active {
   outline: 0;
   background-image: none;
-  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
 .btn-more.disabled,
@@ -12285,7 +12179,6 @@ fieldset[disabled] .btn-more {
   cursor: not-allowed;
   opacity: 0.35;
   filter: alpha(opacity=35);
-  -webkit-box-shadow: none;
   box-shadow: none;
 }
 a.btn-more.disabled,
@@ -12527,7 +12420,6 @@ fieldset[disabled] a.btn-more {
   vertical-align: middle;
   display: inline-block;
   height: 100%;
-  -webkit-transition: opacity .3s;
   transition: opacity .3s;
 }
 .service-tile .teaser {
@@ -12536,7 +12428,6 @@ fieldset[disabled] a.btn-more {
   left: 0;
   width: 100%;
   background: #000;
-  background: -webkit-linear-gradient(top, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0.6) 30%, #000000 100%);
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0.6) 0%, rgba(0, 0, 0, 0.6) 30%, #000000 100%);
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#cc000000', endColorstr='#000000', GradientType=0);
   color: #fff;
@@ -12548,7 +12439,6 @@ fieldset[disabled] a.btn-more {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 100%;
-  -webkit-transition: all .3s;
   transition: all .3s;
 }
 .service-tile .teaser .title:hover {
@@ -12692,13 +12582,7 @@ fieldset[disabled] a.btn-more {
   background: #d6d6d6;
   display: block;
   -webkit-backface-visibility: visible;
-  -webkit-transition: opacity 200ms ease;
-  -moz-transition: opacity 200ms ease;
-  -ms-transition: opacity 200ms ease;
-  -o-transition: opacity 200ms ease;
   transition: opacity 200ms ease;
-  -webkit-border-radius: 30px;
-  -moz-border-radius: 30px;
   border-radius: 30px;
 }
 .carousel .owl-dots .owl-dot.active span,
@@ -12808,7 +12692,6 @@ fieldset[disabled] a.btn-more {
 .carousel-video .owl-nav .owl-next,
 .carousel-video-submenu .owl-nav .owl-next,
 .carousel-content .owl-nav .owl-next {
-  -webkit-transition: left 400ms ease, right 400ms ease;
   transition: left 400ms ease, right 400ms ease;
   margin: -1em 0 0;
 }
@@ -12912,7 +12795,6 @@ fieldset[disabled] a.btn-more {
   text-align: center;
   vertical-align: middle;
   opacity: 0;
-  -webkit-transition: opacity .25s ease;
   transition: opacity .25s ease;
   color: rgba(255, 255, 255, 0.8);
   display: -webkit-box;
@@ -12977,7 +12859,6 @@ fieldset[disabled] a.btn-more {
   text-align: center;
   vertical-align: middle;
   opacity: 0;
-  -webkit-transition: opacity .25s ease;
   transition: opacity .25s ease;
   color: rgba(255, 255, 255, 0.8);
   display: -webkit-box;
@@ -13046,8 +12927,6 @@ fieldset[disabled] a.btn-more {
   float: left;
   margin: 0 5px 0 0;
   font-stretch: normal;
-  -webkit-border-radius: 5px;
-  -moz-border-radius: 5px;
   border-radius: 15px;
   outline-style: none;
   /* remove outlines, for FF */
@@ -13391,7 +13270,6 @@ html:not(.ie8) .stats-highlight img {
 .mapthat-facet-item.active {
   outline: 0;
   background-image: none;
-  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
   box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
 }
 .mapthat-facet-item.disabled,
@@ -13400,7 +13278,6 @@ fieldset[disabled] .mapthat-facet-item {
   cursor: not-allowed;
   opacity: 0.35;
   filter: alpha(opacity=35);
-  -webkit-box-shadow: none;
   box-shadow: none;
 }
 a.mapthat-facet-item.disabled,
@@ -13471,8 +13348,6 @@ fieldset[disabled] .mapthat-facet-item.active {
   background-color: #fff;
   border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.3);
-  -webkit-box-shadow: 0 1px 4px 0 rgba(50, 50, 50, 0.25);
-  -moz-box-shadow: 0 1px 4px 0 rgba(50, 50, 50, 0.25);
   box-shadow: 0 1px 4px 0 rgba(50, 50, 50, 0.25);
 }
 .mapthat_container_search_box svg {
@@ -13488,7 +13363,6 @@ fieldset[disabled] .mapthat-facet-item.active {
   height: 28px;
   opacity: 0;
   position: relative;
-  -webkit-transition: all 0.25s cubic-bezier(0.345, 0, 0.25, 1) 0s;
   transition: all 0.25s cubic-bezier(0.345, 0, 0.25, 1) 0s;
   width: 28px;
   border: medium none;

--- a/css/cagov.font-only.css
+++ b/css/cagov.font-only.css
@@ -1,4 +1,4 @@
-/* cagov-template-v5 - v0.0.1 - Sep-13-2017 */
+/* cagov-template-v5 - v0.0.1 */
 /* STYLES COMPILED FROM SOURCE (LESS) DO NOT MODIFY */
 /* -----------------------------------------
  Helper Mixins for service-group

--- a/css/colorscheme-oceanside.css
+++ b/css/colorscheme-oceanside.css
@@ -1,4 +1,4 @@
-/* cagov-template-v5 - v0.0.1 - Oct-26-2017 */
+/* cagov-template-v5 - v0.0.1 */
 /* STYLES COMPILED FROM SOURCE (LESS) DO NOT MODIFY */
 /* -----------------------------------------
  Helper Mixins for service-group
@@ -54,6 +54,8 @@ color-p3 {
 .global-header {
   /* Default header pattern */
   /* Small screen gets solid color */
+}
+@media (max-width: 767px) {
 }
 .explore-invite a:hover span[class^="ca-gov-icon-"] {
   color: #FDB81E;

--- a/js/cagov.core.js
+++ b/js/cagov.core.js
@@ -8,88 +8,88 @@
 
 
 +function ($) {
-    'use strict';
+  'use strict';
 
-    // ALERT CLASS DEFINITION
-    // ======================
+  // ALERT CLASS DEFINITION
+  // ======================
 
-    var dismiss = '[data-dismiss="alert"]'
-    var Alert = function (el) {
-        $(el).on('click', dismiss, this.close)
+  var dismiss = '[data-dismiss="alert"]'
+  var Alert   = function (el) {
+    $(el).on('click', dismiss, this.close)
+  }
+
+  Alert.VERSION = '3.3.5'
+
+  Alert.TRANSITION_DURATION = 150
+
+  Alert.prototype.close = function (e) {
+    var $this    = $(this)
+    var selector = $this.attr('data-target')
+
+    if (!selector) {
+      selector = $this.attr('href')
+      selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    Alert.VERSION = '3.3.5'
+    var $parent = $(selector)
 
-    Alert.TRANSITION_DURATION = 150
+    if (e) e.preventDefault()
 
-    Alert.prototype.close = function (e) {
-        var $this = $(this)
-        var selector = $this.attr('data-target')
-
-        if (!selector) {
-            selector = $this.attr('href')
-            selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
-        }
-
-        var $parent = $(selector)
-
-        if (e) e.preventDefault()
-
-        if (!$parent.length) {
-            $parent = $this.closest('.alert')
-        }
-
-        $parent.trigger(e = $.Event('close.bs.alert'))
-
-        if (e.isDefaultPrevented()) return
-
-        $parent.removeClass('in')
-
-        function removeElement() {
-            // detach from parent, fire event then clean up data
-            $parent.detach().trigger('closed.bs.alert').remove()
-        }
-
-        $.support.transition && $parent.hasClass('fade') ?
-          $parent
-            .one('bsTransitionEnd', removeElement)
-            .emulateTransitionEnd(Alert.TRANSITION_DURATION) :
-          removeElement()
+    if (!$parent.length) {
+      $parent = $this.closest('.alert')
     }
 
+    $parent.trigger(e = $.Event('close.bs.alert'))
 
-    // ALERT PLUGIN DEFINITION
-    // =======================
+    if (e.isDefaultPrevented()) return
 
-    function Plugin(option) {
-        return this.each(function () {
-            var $this = $(this)
-            var data = $this.data('bs.alert')
+    $parent.removeClass('in')
 
-            if (!data) $this.data('bs.alert', (data = new Alert(this)))
-            if (typeof option == 'string') data[option].call($this)
-        })
+    function removeElement() {
+      // detach from parent, fire event then clean up data
+      $parent.detach().trigger('closed.bs.alert').remove()
     }
 
-    var old = $.fn.alert
-
-    $.fn.alert = Plugin
-    $.fn.alert.Constructor = Alert
-
-
-    // ALERT NO CONFLICT
-    // =================
-
-    $.fn.alert.noConflict = function () {
-        $.fn.alert = old
-        return this
-    }
+    $.support.transition && $parent.hasClass('fade') ?
+      $parent
+        .one('bsTransitionEnd', removeElement)
+        .emulateTransitionEnd(Alert.TRANSITION_DURATION) :
+      removeElement()
+  }
 
 
-    // ALERT DATA-API
-    // ==============
+  // ALERT PLUGIN DEFINITION
+  // =======================
 
-    $(document).on('click.bs.alert.data-api', dismiss, Alert.prototype.close)
+  function Plugin(option) {
+    return this.each(function () {
+      var $this = $(this)
+      var data  = $this.data('bs.alert')
+
+      if (!data) $this.data('bs.alert', (data = new Alert(this)))
+      if (typeof option == 'string') data[option].call($this)
+    })
+  }
+
+  var old = $.fn.alert
+
+  $.fn.alert             = Plugin
+  $.fn.alert.Constructor = Alert
+
+
+  // ALERT NO CONFLICT
+  // =================
+
+  $.fn.alert.noConflict = function () {
+    $.fn.alert = old
+    return this
+  }
+
+
+  // ALERT DATA-API
+  // ==============
+
+  $(document).on('click.bs.alert.data-api', dismiss, Alert.prototype.close)
 
 }(jQuery);
 
@@ -103,114 +103,114 @@
 
 
 +function ($) {
-    'use strict';
+  'use strict';
 
-    // BUTTON PUBLIC CLASS DEFINITION
-    // ==============================
+  // BUTTON PUBLIC CLASS DEFINITION
+  // ==============================
 
-    var Button = function (element, options) {
-        this.$element = $(element)
-        this.options = $.extend({}, Button.DEFAULTS, options)
+  var Button = function (element, options) {
+    this.$element  = $(element)
+    this.options   = $.extend({}, Button.DEFAULTS, options)
+    this.isLoading = false
+  }
+
+  Button.VERSION  = '3.3.5'
+
+  Button.DEFAULTS = {
+    loadingText: 'loading...'
+  }
+
+  Button.prototype.setState = function (state) {
+    var d    = 'disabled'
+    var $el  = this.$element
+    var val  = $el.is('input') ? 'val' : 'html'
+    var data = $el.data()
+
+    state += 'Text'
+
+    if (data.resetText == null) $el.data('resetText', $el[val]())
+
+    // push to event loop to allow forms to submit
+    setTimeout($.proxy(function () {
+      $el[val](data[state] == null ? this.options[state] : data[state])
+
+      if (state == 'loadingText') {
+        this.isLoading = true
+        $el.addClass(d).attr(d, d)
+      } else if (this.isLoading) {
         this.isLoading = false
+        $el.removeClass(d).removeAttr(d)
+      }
+    }, this), 0)
+  }
+
+  Button.prototype.toggle = function () {
+    var changed = true
+    var $parent = this.$element.closest('[data-toggle="buttons"]')
+
+    if ($parent.length) {
+      var $input = this.$element.find('input')
+      if ($input.prop('type') == 'radio') {
+        if ($input.prop('checked')) changed = false
+        $parent.find('.active').removeClass('active')
+        this.$element.addClass('active')
+      } else if ($input.prop('type') == 'checkbox') {
+        if (($input.prop('checked')) !== this.$element.hasClass('active')) changed = false
+        this.$element.toggleClass('active')
+      }
+      $input.prop('checked', this.$element.hasClass('active'))
+      if (changed) $input.trigger('change')
+    } else {
+      this.$element.attr('aria-pressed', !this.$element.hasClass('active'))
+      this.$element.toggleClass('active')
     }
-
-    Button.VERSION = '3.3.5'
-
-    Button.DEFAULTS = {
-        loadingText: 'loading...'
-    }
-
-    Button.prototype.setState = function (state) {
-        var d = 'disabled'
-        var $el = this.$element
-        var val = $el.is('input') ? 'val' : 'html'
-        var data = $el.data()
-
-        state += 'Text'
-
-        if (data.resetText == null) $el.data('resetText', $el[val]())
-
-        // push to event loop to allow forms to submit
-        setTimeout($.proxy(function () {
-            $el[val](data[state] == null ? this.options[state] : data[state])
-
-            if (state == 'loadingText') {
-                this.isLoading = true
-                $el.addClass(d).attr(d, d)
-            } else if (this.isLoading) {
-                this.isLoading = false
-                $el.removeClass(d).removeAttr(d)
-            }
-        }, this), 0)
-    }
-
-    Button.prototype.toggle = function () {
-        var changed = true
-        var $parent = this.$element.closest('[data-toggle="buttons"]')
-
-        if ($parent.length) {
-            var $input = this.$element.find('input')
-            if ($input.prop('type') == 'radio') {
-                if ($input.prop('checked')) changed = false
-                $parent.find('.active').removeClass('active')
-                this.$element.addClass('active')
-            } else if ($input.prop('type') == 'checkbox') {
-                if (($input.prop('checked')) !== this.$element.hasClass('active')) changed = false
-                this.$element.toggleClass('active')
-            }
-            $input.prop('checked', this.$element.hasClass('active'))
-            if (changed) $input.trigger('change')
-        } else {
-            this.$element.attr('aria-pressed', !this.$element.hasClass('active'))
-            this.$element.toggleClass('active')
-        }
-    }
+  }
 
 
-    // BUTTON PLUGIN DEFINITION
-    // ========================
+  // BUTTON PLUGIN DEFINITION
+  // ========================
 
-    function Plugin(option) {
-        return this.each(function () {
-            var $this = $(this)
-            var data = $this.data('bs.button')
-            var options = typeof option == 'object' && option
+  function Plugin(option) {
+    return this.each(function () {
+      var $this   = $(this)
+      var data    = $this.data('bs.button')
+      var options = typeof option == 'object' && option
 
-            if (!data) $this.data('bs.button', (data = new Button(this, options)))
+      if (!data) $this.data('bs.button', (data = new Button(this, options)))
 
-            if (option == 'toggle') data.toggle()
-            else if (option) data.setState(option)
-        })
-    }
+      if (option == 'toggle') data.toggle()
+      else if (option) data.setState(option)
+    })
+  }
 
-    var old = $.fn.button
+  var old = $.fn.button
 
-    $.fn.button = Plugin
-    $.fn.button.Constructor = Button
-
-
-    // BUTTON NO CONFLICT
-    // ==================
-
-    $.fn.button.noConflict = function () {
-        $.fn.button = old
-        return this
-    }
+  $.fn.button             = Plugin
+  $.fn.button.Constructor = Button
 
 
-    // BUTTON DATA-API
-    // ===============
+  // BUTTON NO CONFLICT
+  // ==================
 
-    $(document)
-      .on('click.bs.button.data-api', '[data-toggle^="button"]', function (e) {
-          var $btn = $(e.target)
-          if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
-          Plugin.call($btn, 'toggle')
-          if (!($(e.target).is('input[type="radio"]') || $(e.target).is('input[type="checkbox"]'))) e.preventDefault()
-      })
-      .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {
-          $(e.target).closest('.btn').toggleClass('focus', /^focus(in)?$/.test(e.type))
-      })
+  $.fn.button.noConflict = function () {
+    $.fn.button = old
+    return this
+  }
+
+
+  // BUTTON DATA-API
+  // ===============
+
+  $(document)
+    .on('click.bs.button.data-api', '[data-toggle^="button"]', function (e) {
+      var $btn = $(e.target)
+      if (!$btn.hasClass('btn')) $btn = $btn.closest('.btn')
+      Plugin.call($btn, 'toggle')
+      if (!($(e.target).is('input[type="radio"]') || $(e.target).is('input[type="checkbox"]'))) e.preventDefault()
+    })
+    .on('focus.bs.button.data-api blur.bs.button.data-api', '[data-toggle^="button"]', function (e) {
+      $(e.target).closest('.btn').toggleClass('focus', /^focus(in)?$/.test(e.type))
+    })
 
 }(jQuery);
 
@@ -224,205 +224,205 @@
 
 
 +function ($) {
-    'use strict';
+  'use strict';
 
-    // COLLAPSE PUBLIC CLASS DEFINITION
-    // ================================
+  // COLLAPSE PUBLIC CLASS DEFINITION
+  // ================================
 
-    var Collapse = function (element, options) {
-        this.$element = $(element)
-        this.options = $.extend({}, Collapse.DEFAULTS, options)
-        this.$trigger = $('[data-toggle="collapse"][href="#' + element.id + '"],' +
-                               '[data-toggle="collapse"][data-target="#' + element.id + '"]')
-        this.transitioning = null
+  var Collapse = function (element, options) {
+    this.$element      = $(element)
+    this.options       = $.extend({}, Collapse.DEFAULTS, options)
+    this.$trigger      = $('[data-toggle="collapse"][href="#' + element.id + '"],' +
+                           '[data-toggle="collapse"][data-target="#' + element.id + '"]')
+    this.transitioning = null
 
-        if (this.options.parent) {
-            this.$parent = this.getParent()
-        } else {
-            this.addAriaAndCollapsedClass(this.$element, this.$trigger)
-        }
-
-        if (this.options.toggle) this.toggle()
+    if (this.options.parent) {
+      this.$parent = this.getParent()
+    } else {
+      this.addAriaAndCollapsedClass(this.$element, this.$trigger)
     }
 
-    Collapse.VERSION = '3.3.5'
+    if (this.options.toggle) this.toggle()
+  }
 
-    Collapse.TRANSITION_DURATION = 350
+  Collapse.VERSION  = '3.3.5'
 
-    Collapse.DEFAULTS = {
-        toggle: true
+  Collapse.TRANSITION_DURATION = 350
+
+  Collapse.DEFAULTS = {
+    toggle: true
+  }
+
+  Collapse.prototype.dimension = function () {
+    var hasWidth = this.$element.hasClass('width')
+    return hasWidth ? 'width' : 'height'
+  }
+
+  Collapse.prototype.show = function () {
+    if (this.transitioning || this.$element.hasClass('in')) return
+
+    var activesData
+    var actives = this.$parent && this.$parent.children('.panel').children('.in, .collapsing')
+
+    if (actives && actives.length) {
+      activesData = actives.data('bs.collapse')
+      if (activesData && activesData.transitioning) return
     }
 
-    Collapse.prototype.dimension = function () {
-        var hasWidth = this.$element.hasClass('width')
-        return hasWidth ? 'width' : 'height'
+    var startEvent = $.Event('show.bs.collapse')
+    this.$element.trigger(startEvent)
+    if (startEvent.isDefaultPrevented()) return
+
+    if (actives && actives.length) {
+      Plugin.call(actives, 'hide')
+      activesData || actives.data('bs.collapse', null)
     }
 
-    Collapse.prototype.show = function () {
-        if (this.transitioning || this.$element.hasClass('in')) return
+    var dimension = this.dimension()
 
-        var activesData
-        var actives = this.$parent && this.$parent.children('.panel').children('.in, .collapsing')
+    this.$element
+      .removeClass('collapse')
+      .addClass('collapsing')[dimension](0)
+      .attr('aria-expanded', true)
 
-        if (actives && actives.length) {
-            activesData = actives.data('bs.collapse')
-            if (activesData && activesData.transitioning) return
-        }
+    this.$trigger
+      .removeClass('collapsed')
+      .attr('aria-expanded', true)
 
-        var startEvent = $.Event('show.bs.collapse')
-        this.$element.trigger(startEvent)
-        if (startEvent.isDefaultPrevented()) return
+    this.transitioning = 1
 
-        if (actives && actives.length) {
-            Plugin.call(actives, 'hide')
-            activesData || actives.data('bs.collapse', null)
-        }
-
-        var dimension = this.dimension()
-
-        this.$element
-          .removeClass('collapse')
-          .addClass('collapsing')[dimension](0)
-          .attr('aria-expanded', true)
-
-        this.$trigger
-          .removeClass('collapsed')
-          .attr('aria-expanded', true)
-
-        this.transitioning = 1
-
-        var complete = function () {
-            this.$element
-              .removeClass('collapsing')
-              .addClass('collapse in')[dimension]('')
-            this.transitioning = 0
-            this.$element
-              .trigger('shown.bs.collapse')
-        }
-
-        if (!$.support.transition) return complete.call(this)
-
-        var scrollSize = $.camelCase(['scroll', dimension].join('-'))
-
-        this.$element
-          .one('bsTransitionEnd', $.proxy(complete, this))
-          .emulateTransitionEnd(Collapse.TRANSITION_DURATION)[dimension](this.$element[0][scrollSize])
+    var complete = function () {
+      this.$element
+        .removeClass('collapsing')
+        .addClass('collapse in')[dimension]('')
+      this.transitioning = 0
+      this.$element
+        .trigger('shown.bs.collapse')
     }
 
-    Collapse.prototype.hide = function () {
-        if (this.transitioning || !this.$element.hasClass('in')) return
+    if (!$.support.transition) return complete.call(this)
 
-        var startEvent = $.Event('hide.bs.collapse')
-        this.$element.trigger(startEvent)
-        if (startEvent.isDefaultPrevented()) return
+    var scrollSize = $.camelCase(['scroll', dimension].join('-'))
 
-        var dimension = this.dimension()
+    this.$element
+      .one('bsTransitionEnd', $.proxy(complete, this))
+      .emulateTransitionEnd(Collapse.TRANSITION_DURATION)[dimension](this.$element[0][scrollSize])
+  }
 
-        this.$element[dimension](this.$element[dimension]())[0].offsetHeight
+  Collapse.prototype.hide = function () {
+    if (this.transitioning || !this.$element.hasClass('in')) return
 
-        this.$element
-          .addClass('collapsing')
-          .removeClass('collapse in')
-          .attr('aria-expanded', false)
+    var startEvent = $.Event('hide.bs.collapse')
+    this.$element.trigger(startEvent)
+    if (startEvent.isDefaultPrevented()) return
 
-        this.$trigger
-          .addClass('collapsed')
-          .attr('aria-expanded', false)
+    var dimension = this.dimension()
 
-        this.transitioning = 1
+    this.$element[dimension](this.$element[dimension]())[0].offsetHeight
 
-        var complete = function () {
-            this.transitioning = 0
-            this.$element
-              .removeClass('collapsing')
-              .addClass('collapse')
-              .trigger('hidden.bs.collapse')
-        }
+    this.$element
+      .addClass('collapsing')
+      .removeClass('collapse in')
+      .attr('aria-expanded', false)
 
-        if (!$.support.transition) return complete.call(this)
+    this.$trigger
+      .addClass('collapsed')
+      .attr('aria-expanded', false)
 
-        this.$element
-          [dimension](0)
-          .one('bsTransitionEnd', $.proxy(complete, this))
-          .emulateTransitionEnd(Collapse.TRANSITION_DURATION)
+    this.transitioning = 1
+
+    var complete = function () {
+      this.transitioning = 0
+      this.$element
+        .removeClass('collapsing')
+        .addClass('collapse')
+        .trigger('hidden.bs.collapse')
     }
 
-    Collapse.prototype.toggle = function () {
-        this[this.$element.hasClass('in') ? 'hide' : 'show']()
-    }
+    if (!$.support.transition) return complete.call(this)
 
-    Collapse.prototype.getParent = function () {
-        return $(this.options.parent)
-          .find('[data-toggle="collapse"][data-parent="' + this.options.parent + '"]')
-          .each($.proxy(function (i, element) {
-              var $element = $(element)
-              this.addAriaAndCollapsedClass(getTargetFromTrigger($element), $element)
-          }, this))
-          .end()
-    }
+    this.$element
+      [dimension](0)
+      .one('bsTransitionEnd', $.proxy(complete, this))
+      .emulateTransitionEnd(Collapse.TRANSITION_DURATION)
+  }
 
-    Collapse.prototype.addAriaAndCollapsedClass = function ($element, $trigger) {
-        var isOpen = $element.hasClass('in')
+  Collapse.prototype.toggle = function () {
+    this[this.$element.hasClass('in') ? 'hide' : 'show']()
+  }
 
-        $element.attr('aria-expanded', isOpen)
-        $trigger
-          .toggleClass('collapsed', !isOpen)
-          .attr('aria-expanded', isOpen)
-    }
+  Collapse.prototype.getParent = function () {
+    return $(this.options.parent)
+      .find('[data-toggle="collapse"][data-parent="' + this.options.parent + '"]')
+      .each($.proxy(function (i, element) {
+        var $element = $(element)
+        this.addAriaAndCollapsedClass(getTargetFromTrigger($element), $element)
+      }, this))
+      .end()
+  }
 
-    function getTargetFromTrigger($trigger) {
-        var href
-        var target = $trigger.attr('data-target')
-          || (href = $trigger.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') // strip for ie7
+  Collapse.prototype.addAriaAndCollapsedClass = function ($element, $trigger) {
+    var isOpen = $element.hasClass('in')
 
-        return $(target)
-    }
+    $element.attr('aria-expanded', isOpen)
+    $trigger
+      .toggleClass('collapsed', !isOpen)
+      .attr('aria-expanded', isOpen)
+  }
 
+  function getTargetFromTrigger($trigger) {
+    var href
+    var target = $trigger.attr('data-target')
+      || (href = $trigger.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') // strip for ie7
 
-    // COLLAPSE PLUGIN DEFINITION
-    // ==========================
-
-    function Plugin(option) {
-        return this.each(function () {
-            var $this = $(this)
-            var data = $this.data('bs.collapse')
-            var options = $.extend({}, Collapse.DEFAULTS, $this.data(), typeof option == 'object' && option)
-
-            if (!data && options.toggle && /show|hide/.test(option)) options.toggle = false
-            if (!data) $this.data('bs.collapse', (data = new Collapse(this, options)))
-            if (typeof option == 'string') data[option]()
-        })
-    }
-
-    var old = $.fn.collapse
-
-    $.fn.collapse = Plugin
-    $.fn.collapse.Constructor = Collapse
+    return $(target)
+  }
 
 
-    // COLLAPSE NO CONFLICT
-    // ====================
+  // COLLAPSE PLUGIN DEFINITION
+  // ==========================
 
-    $.fn.collapse.noConflict = function () {
-        $.fn.collapse = old
-        return this
-    }
+  function Plugin(option) {
+    return this.each(function () {
+      var $this   = $(this)
+      var data    = $this.data('bs.collapse')
+      var options = $.extend({}, Collapse.DEFAULTS, $this.data(), typeof option == 'object' && option)
 
-
-    // COLLAPSE DATA-API
-    // =================
-
-    $(document).on('click.bs.collapse.data-api', '[data-toggle="collapse"]', function (e) {
-        var $this = $(this)
-
-        if (!$this.attr('data-target')) e.preventDefault()
-
-        var $target = getTargetFromTrigger($this)
-        var data = $target.data('bs.collapse')
-        var option = data ? 'toggle' : $this.data()
-
-        Plugin.call($target, option)
+      if (!data && options.toggle && /show|hide/.test(option)) options.toggle = false
+      if (!data) $this.data('bs.collapse', (data = new Collapse(this, options)))
+      if (typeof option == 'string') data[option]()
     })
+  }
+
+  var old = $.fn.collapse
+
+  $.fn.collapse             = Plugin
+  $.fn.collapse.Constructor = Collapse
+
+
+  // COLLAPSE NO CONFLICT
+  // ====================
+
+  $.fn.collapse.noConflict = function () {
+    $.fn.collapse = old
+    return this
+  }
+
+
+  // COLLAPSE DATA-API
+  // =================
+
+  $(document).on('click.bs.collapse.data-api', '[data-toggle="collapse"]', function (e) {
+    var $this   = $(this)
+
+    if (!$this.attr('data-target')) e.preventDefault()
+
+    var $target = getTargetFromTrigger($this)
+    var data    = $target.data('bs.collapse')
+    var option  = data ? 'toggle' : $this.data()
+
+    Plugin.call($target, option)
+  })
 
 }(jQuery);
 
@@ -436,159 +436,159 @@
 
 
 +function ($) {
-    'use strict';
+  'use strict';
 
-    // DROPDOWN CLASS DEFINITION
-    // =========================
+  // DROPDOWN CLASS DEFINITION
+  // =========================
 
-    var backdrop = '.dropdown-backdrop'
-    var toggle = '[data-toggle="dropdown"]'
-    var Dropdown = function (element) {
-        $(element).on('click.bs.dropdown', this.toggle)
+  var backdrop = '.dropdown-backdrop'
+  var toggle   = '[data-toggle="dropdown"]'
+  var Dropdown = function (element) {
+    $(element).on('click.bs.dropdown', this.toggle)
+  }
+
+  Dropdown.VERSION = '3.3.5'
+
+  function getParent($this) {
+    var selector = $this.attr('data-target')
+
+    if (!selector) {
+      selector = $this.attr('href')
+      selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    Dropdown.VERSION = '3.3.5'
+    var $parent = selector && $(selector)
 
-    function getParent($this) {
-        var selector = $this.attr('data-target')
+    return $parent && $parent.length ? $parent : $this.parent()
+  }
 
-        if (!selector) {
-            selector = $this.attr('href')
-            selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
-        }
+  function clearMenus(e) {
+    if (e && e.which === 3) return
+    $(backdrop).remove()
+    $(toggle).each(function () {
+      var $this         = $(this)
+      var $parent       = getParent($this)
+      var relatedTarget = { relatedTarget: this }
 
-        var $parent = selector && $(selector)
+      if (!$parent.hasClass('open')) return
 
-        return $parent && $parent.length ? $parent : $this.parent()
+      if (e && e.type == 'click' && /input|textarea/i.test(e.target.tagName) && $.contains($parent[0], e.target)) return
+
+      $parent.trigger(e = $.Event('hide.bs.dropdown', relatedTarget))
+
+      if (e.isDefaultPrevented()) return
+
+      $this.attr('aria-expanded', 'false')
+      $parent.removeClass('open').trigger('hidden.bs.dropdown', relatedTarget)
+    })
+  }
+
+  Dropdown.prototype.toggle = function (e) {
+    var $this = $(this)
+
+    if ($this.is('.disabled, :disabled')) return
+
+    var $parent  = getParent($this)
+    var isActive = $parent.hasClass('open')
+
+    clearMenus()
+
+    if (!isActive) {
+      if ('ontouchstart' in document.documentElement && !$parent.closest('.navbar-nav').length) {
+        // if mobile we use a backdrop because click events don't delegate
+        $(document.createElement('div'))
+          .addClass('dropdown-backdrop')
+          .insertAfter($(this))
+          .on('click', clearMenus)
+      }
+
+      var relatedTarget = { relatedTarget: this }
+      $parent.trigger(e = $.Event('show.bs.dropdown', relatedTarget))
+
+      if (e.isDefaultPrevented()) return
+
+      $this
+        .trigger('focus')
+        .attr('aria-expanded', 'true')
+
+      $parent
+        .toggleClass('open')
+        .trigger('shown.bs.dropdown', relatedTarget)
     }
 
-    function clearMenus(e) {
-        if (e && e.which === 3) return
-        $(backdrop).remove()
-        $(toggle).each(function () {
-            var $this = $(this)
-            var $parent = getParent($this)
-            var relatedTarget = { relatedTarget: this }
+    return false
+  }
 
-            if (!$parent.hasClass('open')) return
+  Dropdown.prototype.keydown = function (e) {
+    if (!/(38|40|27|32)/.test(e.which) || /input|textarea/i.test(e.target.tagName)) return
 
-            if (e && e.type == 'click' && /input|textarea/i.test(e.target.tagName) && $.contains($parent[0], e.target)) return
+    var $this = $(this)
 
-            $parent.trigger(e = $.Event('hide.bs.dropdown', relatedTarget))
+    e.preventDefault()
+    e.stopPropagation()
 
-            if (e.isDefaultPrevented()) return
+    if ($this.is('.disabled, :disabled')) return
 
-            $this.attr('aria-expanded', 'false')
-            $parent.removeClass('open').trigger('hidden.bs.dropdown', relatedTarget)
-        })
+    var $parent  = getParent($this)
+    var isActive = $parent.hasClass('open')
+
+    if (!isActive && e.which != 27 || isActive && e.which == 27) {
+      if (e.which == 27) $parent.find(toggle).trigger('focus')
+      return $this.trigger('click')
     }
 
-    Dropdown.prototype.toggle = function (e) {
-        var $this = $(this)
+    var desc = ' li:not(.disabled):visible a'
+    var $items = $parent.find('.dropdown-menu' + desc)
 
-        if ($this.is('.disabled, :disabled')) return
+    if (!$items.length) return
 
-        var $parent = getParent($this)
-        var isActive = $parent.hasClass('open')
+    var index = $items.index(e.target)
 
-        clearMenus()
+    if (e.which == 38 && index > 0)                 index--         // up
+    if (e.which == 40 && index < $items.length - 1) index++         // down
+    if (!~index)                                    index = 0
 
-        if (!isActive) {
-            if ('ontouchstart' in document.documentElement && !$parent.closest('.navbar-nav').length) {
-                // if mobile we use a backdrop because click events don't delegate
-                $(document.createElement('div'))
-                  .addClass('dropdown-backdrop')
-                  .insertAfter($(this))
-                  .on('click', clearMenus)
-            }
-
-            var relatedTarget = { relatedTarget: this }
-            $parent.trigger(e = $.Event('show.bs.dropdown', relatedTarget))
-
-            if (e.isDefaultPrevented()) return
-
-            $this
-              .trigger('focus')
-              .attr('aria-expanded', 'true')
-
-            $parent
-              .toggleClass('open')
-              .trigger('shown.bs.dropdown', relatedTarget)
-        }
-
-        return false
-    }
-
-    Dropdown.prototype.keydown = function (e) {
-        if (!/(38|40|27|32)/.test(e.which) || /input|textarea/i.test(e.target.tagName)) return
-
-        var $this = $(this)
-
-        e.preventDefault()
-        e.stopPropagation()
-
-        if ($this.is('.disabled, :disabled')) return
-
-        var $parent = getParent($this)
-        var isActive = $parent.hasClass('open')
-
-        if (!isActive && e.which != 27 || isActive && e.which == 27) {
-            if (e.which == 27) $parent.find(toggle).trigger('focus')
-            return $this.trigger('click')
-        }
-
-        var desc = ' li:not(.disabled):visible a'
-        var $items = $parent.find('.dropdown-menu' + desc)
-
-        if (!$items.length) return
-
-        var index = $items.index(e.target)
-
-        if (e.which == 38 && index > 0) index--         // up
-        if (e.which == 40 && index < $items.length - 1) index++         // down
-        if (!~index) index = 0
-
-        $items.eq(index).trigger('focus')
-    }
+    $items.eq(index).trigger('focus')
+  }
 
 
-    // DROPDOWN PLUGIN DEFINITION
-    // ==========================
+  // DROPDOWN PLUGIN DEFINITION
+  // ==========================
 
-    function Plugin(option) {
-        return this.each(function () {
-            var $this = $(this)
-            var data = $this.data('bs.dropdown')
+  function Plugin(option) {
+    return this.each(function () {
+      var $this = $(this)
+      var data  = $this.data('bs.dropdown')
 
-            if (!data) $this.data('bs.dropdown', (data = new Dropdown(this)))
-            if (typeof option == 'string') data[option].call($this)
-        })
-    }
+      if (!data) $this.data('bs.dropdown', (data = new Dropdown(this)))
+      if (typeof option == 'string') data[option].call($this)
+    })
+  }
 
-    var old = $.fn.dropdown
+  var old = $.fn.dropdown
 
-    $.fn.dropdown = Plugin
-    $.fn.dropdown.Constructor = Dropdown
-
-
-    // DROPDOWN NO CONFLICT
-    // ====================
-
-    $.fn.dropdown.noConflict = function () {
-        $.fn.dropdown = old
-        return this
-    }
+  $.fn.dropdown             = Plugin
+  $.fn.dropdown.Constructor = Dropdown
 
 
-    // APPLY TO STANDARD DROPDOWN ELEMENTS
-    // ===================================
+  // DROPDOWN NO CONFLICT
+  // ====================
 
-    $(document)
-      .on('click.bs.dropdown.data-api', clearMenus)
-      .on('click.bs.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
-      .on('click.bs.dropdown.data-api', toggle, Dropdown.prototype.toggle)
-      .on('keydown.bs.dropdown.data-api', toggle, Dropdown.prototype.keydown)
-      .on('keydown.bs.dropdown.data-api', '.dropdown-menu', Dropdown.prototype.keydown)
+  $.fn.dropdown.noConflict = function () {
+    $.fn.dropdown = old
+    return this
+  }
+
+
+  // APPLY TO STANDARD DROPDOWN ELEMENTS
+  // ===================================
+
+  $(document)
+    .on('click.bs.dropdown.data-api', clearMenus)
+    .on('click.bs.dropdown.data-api', '.dropdown form', function (e) { e.stopPropagation() })
+    .on('click.bs.dropdown.data-api', toggle, Dropdown.prototype.toggle)
+    .on('keydown.bs.dropdown.data-api', toggle, Dropdown.prototype.keydown)
+    .on('keydown.bs.dropdown.data-api', '.dropdown-menu', Dropdown.prototype.keydown)
 
 }(jQuery);
 
@@ -941,149 +941,149 @@
 
 
 +function ($) {
-    'use strict';
+  'use strict';
 
-    // TAB CLASS DEFINITION
-    // ====================
+  // TAB CLASS DEFINITION
+  // ====================
 
-    var Tab = function (element) {
-        // jscs:disable requireDollarBeforejQueryAssignment
-        this.element = $(element)
-        // jscs:enable requireDollarBeforejQueryAssignment
+  var Tab = function (element) {
+    // jscs:disable requireDollarBeforejQueryAssignment
+    this.element = $(element)
+    // jscs:enable requireDollarBeforejQueryAssignment
+  }
+
+  Tab.VERSION = '3.3.5'
+
+  Tab.TRANSITION_DURATION = 150
+
+  Tab.prototype.show = function () {
+    var $this    = this.element
+    var $ul      = $this.closest('ul:not(.dropdown-menu)')
+    var selector = $this.data('target')
+
+    if (!selector) {
+      selector = $this.attr('href')
+      selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    Tab.VERSION = '3.3.5'
+    if ($this.parent('li').hasClass('active')) return
 
-    Tab.TRANSITION_DURATION = 150
+    var $previous = $ul.find('.active:last a')
+    var hideEvent = $.Event('hide.bs.tab', {
+      relatedTarget: $this[0]
+    })
+    var showEvent = $.Event('show.bs.tab', {
+      relatedTarget: $previous[0]
+    })
 
-    Tab.prototype.show = function () {
-        var $this = this.element
-        var $ul = $this.closest('ul:not(.dropdown-menu)')
-        var selector = $this.data('target')
+    $previous.trigger(hideEvent)
+    $this.trigger(showEvent)
 
-        if (!selector) {
-            selector = $this.attr('href')
-            selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
-        }
+    if (showEvent.isDefaultPrevented() || hideEvent.isDefaultPrevented()) return
 
-        if ($this.parent('li').hasClass('active')) return
+    var $target = $(selector)
 
-        var $previous = $ul.find('.active:last a')
-        var hideEvent = $.Event('hide.bs.tab', {
-            relatedTarget: $this[0]
-        })
-        var showEvent = $.Event('show.bs.tab', {
-            relatedTarget: $previous[0]
-        })
+    this.activate($this.closest('li'), $ul)
+    this.activate($target, $target.parent(), function () {
+      $previous.trigger({
+        type: 'hidden.bs.tab',
+        relatedTarget: $this[0]
+      })
+      $this.trigger({
+        type: 'shown.bs.tab',
+        relatedTarget: $previous[0]
+      })
+    })
+  }
 
-        $previous.trigger(hideEvent)
-        $this.trigger(showEvent)
+  Tab.prototype.activate = function (element, container, callback) {
+    var $active    = container.find('> .active')
+    var transition = callback
+      && $.support.transition
+      && ($active.length && $active.hasClass('fade') || !!container.find('> .fade').length)
 
-        if (showEvent.isDefaultPrevented() || hideEvent.isDefaultPrevented()) return
+    function next() {
+      $active
+        .removeClass('active')
+        .find('> .dropdown-menu > .active')
+          .removeClass('active')
+        .end()
+        .find('[data-toggle="tab"]')
+          .attr('aria-expanded', false)
 
-        var $target = $(selector)
+      element
+        .addClass('active')
+        .find('[data-toggle="tab"]')
+          .attr('aria-expanded', true)
 
-        this.activate($this.closest('li'), $ul)
-        this.activate($target, $target.parent(), function () {
-            $previous.trigger({
-                type: 'hidden.bs.tab',
-                relatedTarget: $this[0]
-            })
-            $this.trigger({
-                type: 'shown.bs.tab',
-                relatedTarget: $previous[0]
-            })
-        })
+      if (transition) {
+        element[0].offsetWidth // reflow for transition
+        element.addClass('in')
+      } else {
+        element.removeClass('fade')
+      }
+
+      if (element.parent('.dropdown-menu').length) {
+        element
+          .closest('li.dropdown')
+            .addClass('active')
+          .end()
+          .find('[data-toggle="tab"]')
+            .attr('aria-expanded', true)
+      }
+
+      callback && callback()
     }
 
-    Tab.prototype.activate = function (element, container, callback) {
-        var $active = container.find('> .active')
-        var transition = callback
-          && $.support.transition
-          && ($active.length && $active.hasClass('fade') || !!container.find('> .fade').length)
+    $active.length && transition ?
+      $active
+        .one('bsTransitionEnd', next)
+        .emulateTransitionEnd(Tab.TRANSITION_DURATION) :
+      next()
 
-        function next() {
-            $active
-              .removeClass('active')
-              .find('> .dropdown-menu > .active')
-                .removeClass('active')
-              .end()
-              .find('[data-toggle="tab"]')
-                .attr('aria-expanded', false)
-
-            element
-              .addClass('active')
-              .find('[data-toggle="tab"]')
-                .attr('aria-expanded', true)
-
-            if (transition) {
-                element[0].offsetWidth // reflow for transition
-                element.addClass('in')
-            } else {
-                element.removeClass('fade')
-            }
-
-            if (element.parent('.dropdown-menu').length) {
-                element
-                  .closest('li.dropdown')
-                    .addClass('active')
-                  .end()
-                  .find('[data-toggle="tab"]')
-                    .attr('aria-expanded', true)
-            }
-
-            callback && callback()
-        }
-
-        $active.length && transition ?
-          $active
-            .one('bsTransitionEnd', next)
-            .emulateTransitionEnd(Tab.TRANSITION_DURATION) :
-          next()
-
-        $active.removeClass('in')
-    }
+    $active.removeClass('in')
+  }
 
 
-    // TAB PLUGIN DEFINITION
-    // =====================
+  // TAB PLUGIN DEFINITION
+  // =====================
 
-    function Plugin(option) {
-        return this.each(function () {
-            var $this = $(this)
-            var data = $this.data('bs.tab')
+  function Plugin(option) {
+    return this.each(function () {
+      var $this = $(this)
+      var data  = $this.data('bs.tab')
 
-            if (!data) $this.data('bs.tab', (data = new Tab(this)))
-            if (typeof option == 'string') data[option]()
-        })
-    }
+      if (!data) $this.data('bs.tab', (data = new Tab(this)))
+      if (typeof option == 'string') data[option]()
+    })
+  }
 
-    var old = $.fn.tab
+  var old = $.fn.tab
 
-    $.fn.tab = Plugin
-    $.fn.tab.Constructor = Tab
-
-
-    // TAB NO CONFLICT
-    // ===============
-
-    $.fn.tab.noConflict = function () {
-        $.fn.tab = old
-        return this
-    }
+  $.fn.tab             = Plugin
+  $.fn.tab.Constructor = Tab
 
 
-    // TAB DATA-API
-    // ============
+  // TAB NO CONFLICT
+  // ===============
 
-    var clickHandler = function (e) {
-        e.preventDefault()
-        Plugin.call($(this), 'show')
-    }
+  $.fn.tab.noConflict = function () {
+    $.fn.tab = old
+    return this
+  }
 
-    $(document)
-      .on('click.bs.tab.data-api', '[data-toggle="tab"]', clickHandler)
-      .on('click.bs.tab.data-api', '[data-toggle="pill"]', clickHandler)
+
+  // TAB DATA-API
+  // ============
+
+  var clickHandler = function (e) {
+    e.preventDefault()
+    Plugin.call($(this), 'show')
+  }
+
+  $(document)
+    .on('click.bs.tab.data-api', '[data-toggle="tab"]', clickHandler)
+    .on('click.bs.tab.data-api', '[data-toggle="pill"]', clickHandler)
 
 }(jQuery);
 
@@ -1097,53 +1097,53 @@
 
 
 +function ($) {
-    'use strict';
+  'use strict';
 
-    // CSS TRANSITION SUPPORT (Shoutout: http://www.modernizr.com/)
-    // ============================================================
+  // CSS TRANSITION SUPPORT (Shoutout: http://www.modernizr.com/)
+  // ============================================================
 
-    function transitionEnd() {
-        var el = document.createElement('bootstrap')
+  function transitionEnd() {
+    var el = document.createElement('bootstrap')
 
-        var transEndEventNames = {
-            WebkitTransition: 'webkitTransitionEnd',
-            MozTransition: 'transitionend',
-            OTransition: 'oTransitionEnd otransitionend',
-            transition: 'transitionend'
-        }
-
-        for (var name in transEndEventNames) {
-            if (el.style[name] !== undefined) {
-                return { end: transEndEventNames[name] }
-            }
-        }
-
-        return false // explicit for ie8 (  ._.)
+    var transEndEventNames = {
+      WebkitTransition : 'webkitTransitionEnd',
+      MozTransition    : 'transitionend',
+      OTransition      : 'oTransitionEnd otransitionend',
+      transition       : 'transitionend'
     }
 
-    // http://blog.alexmaccaw.com/css-transitions
-    $.fn.emulateTransitionEnd = function (duration) {
-        var called = false
-        var $el = this
-        $(this).one('bsTransitionEnd', function () { called = true })
-        var callback = function () { if (!called) $($el).trigger($.support.transition.end) }
-        setTimeout(callback, duration)
-        return this
+    for (var name in transEndEventNames) {
+      if (el.style[name] !== undefined) {
+        return { end: transEndEventNames[name] }
+      }
     }
 
-    $(function () {
-        $.support.transition = transitionEnd()
+    return false // explicit for ie8 (  ._.)
+  }
 
-        if (!$.support.transition) return
+  // http://blog.alexmaccaw.com/css-transitions
+  $.fn.emulateTransitionEnd = function (duration) {
+    var called = false
+    var $el = this
+    $(this).one('bsTransitionEnd', function () { called = true })
+    var callback = function () { if (!called) $($el).trigger($.support.transition.end) }
+    setTimeout(callback, duration)
+    return this
+  }
 
-        $.event.special.bsTransitionEnd = {
-            bindType: $.support.transition.end,
-            delegateType: $.support.transition.end,
-            handle: function (e) {
-                if ($(e.target).is(this)) return e.handleObj.handler.apply(this, arguments)
-            }
-        }
-    })
+  $(function () {
+    $.support.transition = transitionEnd()
+
+    if (!$.support.transition) return
+
+    $.event.special.bsTransitionEnd = {
+      bindType: $.support.transition.end,
+      delegateType: $.support.transition.end,
+      handle: function (e) {
+        if ($(e.target).is(this)) return e.handleObj.handler.apply(this, arguments)
+      }
+    }
+  })
 
 }(jQuery);
 
@@ -1158,843 +1158,843 @@
 
 
 +function ($) {
-    'use strict';
+  'use strict';
 
-    // TOOLTIP PUBLIC CLASS DEFINITION
-    // ===============================
+  // TOOLTIP PUBLIC CLASS DEFINITION
+  // ===============================
 
-    var Tooltip = function (element, options) {
-        this.type = null
-        this.options = null
-        this.enabled = null
-        this.timeout = null
-        this.hoverState = null
-        this.$element = null
-        this.inState = null
+  var Tooltip = function (element, options) {
+    this.type       = null
+    this.options    = null
+    this.enabled    = null
+    this.timeout    = null
+    this.hoverState = null
+    this.$element   = null
+    this.inState    = null
 
-        this.init('tooltip', element, options)
+    this.init('tooltip', element, options)
+  }
+
+  Tooltip.VERSION  = '3.3.5'
+
+  Tooltip.TRANSITION_DURATION = 150
+
+  Tooltip.DEFAULTS = {
+    animation: true,
+    placement: 'top',
+    selector: false,
+    template: '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>',
+    trigger: 'hover focus',
+    title: '',
+    delay: 0,
+    html: false,
+    container: false,
+    viewport: {
+      selector: 'body',
+      padding: 0
+    }
+  }
+
+  Tooltip.prototype.init = function (type, element, options) {
+    this.enabled   = true
+    this.type      = type
+    this.$element  = $(element)
+    this.options   = this.getOptions(options)
+    this.$viewport = this.options.viewport && $($.isFunction(this.options.viewport) ? this.options.viewport.call(this, this.$element) : (this.options.viewport.selector || this.options.viewport))
+    this.inState   = { click: false, hover: false, focus: false }
+
+    if (this.$element[0] instanceof document.constructor && !this.options.selector) {
+      throw new Error('`selector` option must be specified when initializing ' + this.type + ' on the window.document object!')
     }
 
-    Tooltip.VERSION = '3.3.5'
+    var triggers = this.options.trigger.split(' ')
 
-    Tooltip.TRANSITION_DURATION = 150
+    for (var i = triggers.length; i--;) {
+      var trigger = triggers[i]
 
-    Tooltip.DEFAULTS = {
-        animation: true,
-        placement: 'top',
-        selector: false,
-        template: '<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>',
-        trigger: 'hover focus',
-        title: '',
-        delay: 0,
-        html: false,
-        container: false,
-        viewport: {
-            selector: 'body',
-            padding: 0
-        }
+      if (trigger == 'click') {
+        this.$element.on('click.' + this.type, this.options.selector, $.proxy(this.toggle, this))
+      } else if (trigger != 'manual') {
+        var eventIn  = trigger == 'hover' ? 'mouseenter' : 'focusin'
+        var eventOut = trigger == 'hover' ? 'mouseleave' : 'focusout'
+
+        this.$element.on(eventIn  + '.' + this.type, this.options.selector, $.proxy(this.enter, this))
+        this.$element.on(eventOut + '.' + this.type, this.options.selector, $.proxy(this.leave, this))
+      }
     }
 
-    Tooltip.prototype.init = function (type, element, options) {
-        this.enabled = true
-        this.type = type
-        this.$element = $(element)
-        this.options = this.getOptions(options)
-        this.$viewport = this.options.viewport && $($.isFunction(this.options.viewport) ? this.options.viewport.call(this, this.$element) : (this.options.viewport.selector || this.options.viewport))
-        this.inState = { click: false, hover: false, focus: false }
+    this.options.selector ?
+      (this._options = $.extend({}, this.options, { trigger: 'manual', selector: '' })) :
+      this.fixTitle()
+  }
 
-        if (this.$element[0] instanceof document.constructor && !this.options.selector) {
-            throw new Error('`selector` option must be specified when initializing ' + this.type + ' on the window.document object!')
-        }
+  Tooltip.prototype.getDefaults = function () {
+    return Tooltip.DEFAULTS
+  }
 
-        var triggers = this.options.trigger.split(' ')
+  Tooltip.prototype.getOptions = function (options) {
+    options = $.extend({}, this.getDefaults(), this.$element.data(), options)
 
-        for (var i = triggers.length; i--;) {
-            var trigger = triggers[i]
-
-            if (trigger == 'click') {
-                this.$element.on('click.' + this.type, this.options.selector, $.proxy(this.toggle, this))
-            } else if (trigger != 'manual') {
-                var eventIn = trigger == 'hover' ? 'mouseenter' : 'focusin'
-                var eventOut = trigger == 'hover' ? 'mouseleave' : 'focusout'
-
-                this.$element.on(eventIn + '.' + this.type, this.options.selector, $.proxy(this.enter, this))
-                this.$element.on(eventOut + '.' + this.type, this.options.selector, $.proxy(this.leave, this))
-            }
-        }
-
-        this.options.selector ?
-          (this._options = $.extend({}, this.options, { trigger: 'manual', selector: '' })) :
-          this.fixTitle()
+    if (options.delay && typeof options.delay == 'number') {
+      options.delay = {
+        show: options.delay,
+        hide: options.delay
+      }
     }
 
-    Tooltip.prototype.getDefaults = function () {
-        return Tooltip.DEFAULTS
+    return options
+  }
+
+  Tooltip.prototype.getDelegateOptions = function () {
+    var options  = {}
+    var defaults = this.getDefaults()
+
+    this._options && $.each(this._options, function (key, value) {
+      if (defaults[key] != value) options[key] = value
+    })
+
+    return options
+  }
+
+  Tooltip.prototype.enter = function (obj) {
+    var self = obj instanceof this.constructor ?
+      obj : $(obj.currentTarget).data('bs.' + this.type)
+
+    if (!self) {
+      self = new this.constructor(obj.currentTarget, this.getDelegateOptions())
+      $(obj.currentTarget).data('bs.' + this.type, self)
     }
 
-    Tooltip.prototype.getOptions = function (options) {
-        options = $.extend({}, this.getDefaults(), this.$element.data(), options)
-
-        if (options.delay && typeof options.delay == 'number') {
-            options.delay = {
-                show: options.delay,
-                hide: options.delay
-            }
-        }
-
-        return options
+    if (obj instanceof $.Event) {
+      self.inState[obj.type == 'focusin' ? 'focus' : 'hover'] = true
     }
 
-    Tooltip.prototype.getDelegateOptions = function () {
-        var options = {}
-        var defaults = this.getDefaults()
+    if (self.tip().hasClass('in') || self.hoverState == 'in') {
+      self.hoverState = 'in'
+      return
+    }
 
-        this._options && $.each(this._options, function (key, value) {
-            if (defaults[key] != value) options[key] = value
+    clearTimeout(self.timeout)
+
+    self.hoverState = 'in'
+
+    if (!self.options.delay || !self.options.delay.show) return self.show()
+
+    self.timeout = setTimeout(function () {
+      if (self.hoverState == 'in') self.show()
+    }, self.options.delay.show)
+  }
+
+  Tooltip.prototype.isInStateTrue = function () {
+    for (var key in this.inState) {
+      if (this.inState[key]) return true
+    }
+
+    return false
+  }
+
+  Tooltip.prototype.leave = function (obj) {
+    var self = obj instanceof this.constructor ?
+      obj : $(obj.currentTarget).data('bs.' + this.type)
+
+    if (!self) {
+      self = new this.constructor(obj.currentTarget, this.getDelegateOptions())
+      $(obj.currentTarget).data('bs.' + this.type, self)
+    }
+
+    if (obj instanceof $.Event) {
+      self.inState[obj.type == 'focusout' ? 'focus' : 'hover'] = false
+    }
+
+    if (self.isInStateTrue()) return
+
+    clearTimeout(self.timeout)
+
+    self.hoverState = 'out'
+
+    if (!self.options.delay || !self.options.delay.hide) return self.hide()
+
+    self.timeout = setTimeout(function () {
+      if (self.hoverState == 'out') self.hide()
+    }, self.options.delay.hide)
+  }
+
+  Tooltip.prototype.show = function () {
+    var e = $.Event('show.bs.' + this.type)
+
+    if (this.hasContent() && this.enabled) {
+      this.$element.trigger(e)
+
+      var inDom = $.contains(this.$element[0].ownerDocument.documentElement, this.$element[0])
+      if (e.isDefaultPrevented() || !inDom) return
+      var that = this
+
+      var $tip = this.tip()
+
+      var tipId = this.getUID(this.type)
+
+      this.setContent()
+      $tip.attr('id', tipId)
+      this.$element.attr('aria-describedby', tipId)
+
+      if (this.options.animation) $tip.addClass('fade')
+
+      var placement = typeof this.options.placement == 'function' ?
+        this.options.placement.call(this, $tip[0], this.$element[0]) :
+        this.options.placement
+
+      var autoToken = /\s?auto?\s?/i
+      var autoPlace = autoToken.test(placement)
+      if (autoPlace) placement = placement.replace(autoToken, '') || 'top'
+
+      $tip
+        .detach()
+        .css({ top: 0, left: 0, display: 'block' })
+        .addClass(placement)
+        .data('bs.' + this.type, this)
+
+      this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
+      this.$element.trigger('inserted.bs.' + this.type)
+
+      var pos          = this.getPosition()
+      var actualWidth  = $tip[0].offsetWidth
+      var actualHeight = $tip[0].offsetHeight
+
+      if (autoPlace) {
+        var orgPlacement = placement
+        var viewportDim = this.getPosition(this.$viewport)
+
+        placement = placement == 'bottom' && pos.bottom + actualHeight > viewportDim.bottom ? 'top'    :
+                    placement == 'top'    && pos.top    - actualHeight < viewportDim.top    ? 'bottom' :
+                    placement == 'right'  && pos.right  + actualWidth  > viewportDim.width  ? 'left'   :
+                    placement == 'left'   && pos.left   - actualWidth  < viewportDim.left   ? 'right'  :
+                    placement
+
+        $tip
+          .removeClass(orgPlacement)
+          .addClass(placement)
+      }
+
+      var calculatedOffset = this.getCalculatedOffset(placement, pos, actualWidth, actualHeight)
+
+      this.applyPlacement(calculatedOffset, placement)
+
+      var complete = function () {
+        var prevHoverState = that.hoverState
+        that.$element.trigger('shown.bs.' + that.type)
+        that.hoverState = null
+
+        if (prevHoverState == 'out') that.leave(that)
+      }
+
+      $.support.transition && this.$tip.hasClass('fade') ?
+        $tip
+          .one('bsTransitionEnd', complete)
+          .emulateTransitionEnd(Tooltip.TRANSITION_DURATION) :
+        complete()
+    }
+  }
+
+  Tooltip.prototype.applyPlacement = function (offset, placement) {
+    var $tip   = this.tip()
+    var width  = $tip[0].offsetWidth
+    var height = $tip[0].offsetHeight
+
+    // manually read margins because getBoundingClientRect includes difference
+    var marginTop = parseInt($tip.css('margin-top'), 10)
+    var marginLeft = parseInt($tip.css('margin-left'), 10)
+
+    // we must check for NaN for ie 8/9
+    if (isNaN(marginTop))  marginTop  = 0
+    if (isNaN(marginLeft)) marginLeft = 0
+
+    offset.top  += marginTop
+    offset.left += marginLeft
+
+    // $.fn.offset doesn't round pixel values
+    // so we use setOffset directly with our own function B-0
+    $.offset.setOffset($tip[0], $.extend({
+      using: function (props) {
+        $tip.css({
+          top: Math.round(props.top),
+          left: Math.round(props.left)
         })
+      }
+    }, offset), 0)
 
-        return options
+    $tip.addClass('in')
+
+    // check to see if placing tip in new offset caused the tip to resize itself
+    var actualWidth  = $tip[0].offsetWidth
+    var actualHeight = $tip[0].offsetHeight
+
+    if (placement == 'top' && actualHeight != height) {
+      offset.top = offset.top + height - actualHeight
     }
 
-    Tooltip.prototype.enter = function (obj) {
-        var self = obj instanceof this.constructor ?
-            obj : $(obj.currentTarget).data('bs.' + this.type)
+    var delta = this.getViewportAdjustedDelta(placement, offset, actualWidth, actualHeight)
 
-        if (!self) {
-            self = new this.constructor(obj.currentTarget, this.getDelegateOptions())
-            $(obj.currentTarget).data('bs.' + this.type, self)
-        }
+    if (delta.left) offset.left += delta.left
+    else offset.top += delta.top
 
-        if (obj instanceof $.Event) {
-            self.inState[obj.type == 'focusin' ? 'focus' : 'hover'] = true
-        }
+    var isVertical          = /top|bottom/.test(placement)
+    var arrowDelta          = isVertical ? delta.left * 2 - width + actualWidth : delta.top * 2 - height + actualHeight
+    var arrowOffsetPosition = isVertical ? 'offsetWidth' : 'offsetHeight'
 
-        if (self.tip().hasClass('in') || self.hoverState == 'in') {
-            self.hoverState = 'in'
-            return
-        }
+    $tip.offset(offset)
+    this.replaceArrow(arrowDelta, $tip[0][arrowOffsetPosition], isVertical)
+  }
 
-        clearTimeout(self.timeout)
+  Tooltip.prototype.replaceArrow = function (delta, dimension, isVertical) {
+    this.arrow()
+      .css(isVertical ? 'left' : 'top', 50 * (1 - delta / dimension) + '%')
+      .css(isVertical ? 'top' : 'left', '')
+  }
 
-        self.hoverState = 'in'
+  Tooltip.prototype.setContent = function () {
+    var $tip  = this.tip()
+    var title = this.getTitle()
 
-        if (!self.options.delay || !self.options.delay.show) return self.show()
+    $tip.find('.tooltip-inner')[this.options.html ? 'html' : 'text'](title)
+    $tip.removeClass('fade in top bottom left right')
+  }
 
-        self.timeout = setTimeout(function () {
-            if (self.hoverState == 'in') self.show()
-        }, self.options.delay.show)
+  Tooltip.prototype.hide = function (callback) {
+    var that = this
+    var $tip = $(this.$tip)
+    var e    = $.Event('hide.bs.' + this.type)
+
+    function complete() {
+      if (that.hoverState != 'in') $tip.detach()
+      that.$element
+        .removeAttr('aria-describedby')
+        .trigger('hidden.bs.' + that.type)
+      callback && callback()
     }
 
-    Tooltip.prototype.isInStateTrue = function () {
-        for (var key in this.inState) {
-            if (this.inState[key]) return true
-        }
+    this.$element.trigger(e)
 
-        return false
+    if (e.isDefaultPrevented()) return
+
+    $tip.removeClass('in')
+
+    $.support.transition && $tip.hasClass('fade') ?
+      $tip
+        .one('bsTransitionEnd', complete)
+        .emulateTransitionEnd(Tooltip.TRANSITION_DURATION) :
+      complete()
+
+    this.hoverState = null
+
+    return this
+  }
+
+  Tooltip.prototype.fixTitle = function () {
+    var $e = this.$element
+    if ($e.attr('title') || typeof $e.attr('data-original-title') != 'string') {
+      $e.attr('data-original-title', $e.attr('title') || '').attr('title', '')
+    }
+  }
+
+  Tooltip.prototype.hasContent = function () {
+    return this.getTitle()
+  }
+
+  Tooltip.prototype.getPosition = function ($element) {
+    $element   = $element || this.$element
+
+    var el     = $element[0]
+    var isBody = el.tagName == 'BODY'
+
+    var elRect    = el.getBoundingClientRect()
+    if (elRect.width == null) {
+      // width and height are missing in IE8, so compute them manually; see https://github.com/twbs/bootstrap/issues/14093
+      elRect = $.extend({}, elRect, { width: elRect.right - elRect.left, height: elRect.bottom - elRect.top })
+    }
+    var elOffset  = isBody ? { top: 0, left: 0 } : $element.offset()
+    var scroll    = { scroll: isBody ? document.documentElement.scrollTop || document.body.scrollTop : $element.scrollTop() }
+    var outerDims = isBody ? { width: $(window).width(), height: $(window).height() } : null
+
+    return $.extend({}, elRect, scroll, outerDims, elOffset)
+  }
+
+  Tooltip.prototype.getCalculatedOffset = function (placement, pos, actualWidth, actualHeight) {
+    return placement == 'bottom' ? { top: pos.top + pos.height,   left: pos.left + pos.width / 2 - actualWidth / 2 } :
+           placement == 'top'    ? { top: pos.top - actualHeight, left: pos.left + pos.width / 2 - actualWidth / 2 } :
+           placement == 'left'   ? { top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth } :
+        /* placement == 'right' */ { top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width }
+
+  }
+
+  Tooltip.prototype.getViewportAdjustedDelta = function (placement, pos, actualWidth, actualHeight) {
+    var delta = { top: 0, left: 0 }
+    if (!this.$viewport) return delta
+
+    var viewportPadding = this.options.viewport && this.options.viewport.padding || 0
+    var viewportDimensions = this.getPosition(this.$viewport)
+
+    if (/right|left/.test(placement)) {
+      var topEdgeOffset    = pos.top - viewportPadding - viewportDimensions.scroll
+      var bottomEdgeOffset = pos.top + viewportPadding - viewportDimensions.scroll + actualHeight
+      if (topEdgeOffset < viewportDimensions.top) { // top overflow
+        delta.top = viewportDimensions.top - topEdgeOffset
+      } else if (bottomEdgeOffset > viewportDimensions.top + viewportDimensions.height) { // bottom overflow
+        delta.top = viewportDimensions.top + viewportDimensions.height - bottomEdgeOffset
+      }
+    } else {
+      var leftEdgeOffset  = pos.left - viewportPadding
+      var rightEdgeOffset = pos.left + viewportPadding + actualWidth
+      if (leftEdgeOffset < viewportDimensions.left) { // left overflow
+        delta.left = viewportDimensions.left - leftEdgeOffset
+      } else if (rightEdgeOffset > viewportDimensions.right) { // right overflow
+        delta.left = viewportDimensions.left + viewportDimensions.width - rightEdgeOffset
+      }
     }
 
-    Tooltip.prototype.leave = function (obj) {
-        var self = obj instanceof this.constructor ?
-            obj : $(obj.currentTarget).data('bs.' + this.type)
+    return delta
+  }
 
-        if (!self) {
-            self = new this.constructor(obj.currentTarget, this.getDelegateOptions())
-            $(obj.currentTarget).data('bs.' + this.type, self)
-        }
+  Tooltip.prototype.getTitle = function () {
+    var title
+    var $e = this.$element
+    var o  = this.options
 
-        if (obj instanceof $.Event) {
-            self.inState[obj.type == 'focusout' ? 'focus' : 'hover'] = false
-        }
+    title = $e.attr('data-original-title')
+      || (typeof o.title == 'function' ? o.title.call($e[0]) :  o.title)
 
-        if (self.isInStateTrue()) return
+    return title
+  }
 
-        clearTimeout(self.timeout)
+  Tooltip.prototype.getUID = function (prefix) {
+    do prefix += ~~(Math.random() * 1000000)
+    while (document.getElementById(prefix))
+    return prefix
+  }
 
-        self.hoverState = 'out'
+  Tooltip.prototype.tip = function () {
+    if (!this.$tip) {
+      this.$tip = $(this.options.template)
+      if (this.$tip.length != 1) {
+        throw new Error(this.type + ' `template` option must consist of exactly 1 top-level element!')
+      }
+    }
+    return this.$tip
+  }
 
-        if (!self.options.delay || !self.options.delay.hide) return self.hide()
+  Tooltip.prototype.arrow = function () {
+    return (this.$arrow = this.$arrow || this.tip().find('.tooltip-arrow'))
+  }
 
-        self.timeout = setTimeout(function () {
-            if (self.hoverState == 'out') self.hide()
-        }, self.options.delay.hide)
+  Tooltip.prototype.enable = function () {
+    this.enabled = true
+  }
+
+  Tooltip.prototype.disable = function () {
+    this.enabled = false
+  }
+
+  Tooltip.prototype.toggleEnabled = function () {
+    this.enabled = !this.enabled
+  }
+
+  Tooltip.prototype.toggle = function (e) {
+    var self = this
+    if (e) {
+      self = $(e.currentTarget).data('bs.' + this.type)
+      if (!self) {
+        self = new this.constructor(e.currentTarget, this.getDelegateOptions())
+        $(e.currentTarget).data('bs.' + this.type, self)
+      }
     }
 
-    Tooltip.prototype.show = function () {
-        var e = $.Event('show.bs.' + this.type)
-
-        if (this.hasContent() && this.enabled) {
-            this.$element.trigger(e)
-
-            var inDom = $.contains(this.$element[0].ownerDocument.documentElement, this.$element[0])
-            if (e.isDefaultPrevented() || !inDom) return
-            var that = this
-
-            var $tip = this.tip()
-
-            var tipId = this.getUID(this.type)
-
-            this.setContent()
-            $tip.attr('id', tipId)
-            this.$element.attr('aria-describedby', tipId)
-
-            if (this.options.animation) $tip.addClass('fade')
-
-            var placement = typeof this.options.placement == 'function' ?
-              this.options.placement.call(this, $tip[0], this.$element[0]) :
-              this.options.placement
-
-            var autoToken = /\s?auto?\s?/i
-            var autoPlace = autoToken.test(placement)
-            if (autoPlace) placement = placement.replace(autoToken, '') || 'top'
-
-            $tip
-              .detach()
-              .css({ top: 0, left: 0, display: 'block' })
-              .addClass(placement)
-              .data('bs.' + this.type, this)
-
-            this.options.container ? $tip.appendTo(this.options.container) : $tip.insertAfter(this.$element)
-            this.$element.trigger('inserted.bs.' + this.type)
-
-            var pos = this.getPosition()
-            var actualWidth = $tip[0].offsetWidth
-            var actualHeight = $tip[0].offsetHeight
-
-            if (autoPlace) {
-                var orgPlacement = placement
-                var viewportDim = this.getPosition(this.$viewport)
-
-                placement = placement == 'bottom' && pos.bottom + actualHeight > viewportDim.bottom ? 'top' :
-                            placement == 'top' && pos.top - actualHeight < viewportDim.top ? 'bottom' :
-                            placement == 'right' && pos.right + actualWidth > viewportDim.width ? 'left' :
-                            placement == 'left' && pos.left - actualWidth < viewportDim.left ? 'right' :
-                            placement
-
-                $tip
-                  .removeClass(orgPlacement)
-                  .addClass(placement)
-            }
-
-            var calculatedOffset = this.getCalculatedOffset(placement, pos, actualWidth, actualHeight)
-
-            this.applyPlacement(calculatedOffset, placement)
-
-            var complete = function () {
-                var prevHoverState = that.hoverState
-                that.$element.trigger('shown.bs.' + that.type)
-                that.hoverState = null
-
-                if (prevHoverState == 'out') that.leave(that)
-            }
-
-            $.support.transition && this.$tip.hasClass('fade') ?
-              $tip
-                .one('bsTransitionEnd', complete)
-                .emulateTransitionEnd(Tooltip.TRANSITION_DURATION) :
-              complete()
-        }
+    if (e) {
+      self.inState.click = !self.inState.click
+      if (self.isInStateTrue()) self.enter(self)
+      else self.leave(self)
+    } else {
+      self.tip().hasClass('in') ? self.leave(self) : self.enter(self)
     }
+  }
 
-    Tooltip.prototype.applyPlacement = function (offset, placement) {
-        var $tip = this.tip()
-        var width = $tip[0].offsetWidth
-        var height = $tip[0].offsetHeight
-
-        // manually read margins because getBoundingClientRect includes difference
-        var marginTop = parseInt($tip.css('margin-top'), 10)
-        var marginLeft = parseInt($tip.css('margin-left'), 10)
-
-        // we must check for NaN for ie 8/9
-        if (isNaN(marginTop)) marginTop = 0
-        if (isNaN(marginLeft)) marginLeft = 0
-
-        offset.top += marginTop
-        offset.left += marginLeft
-
-        // $.fn.offset doesn't round pixel values
-        // so we use setOffset directly with our own function B-0
-        $.offset.setOffset($tip[0], $.extend({
-            using: function (props) {
-                $tip.css({
-                    top: Math.round(props.top),
-                    left: Math.round(props.left)
-                })
-            }
-        }, offset), 0)
-
-        $tip.addClass('in')
-
-        // check to see if placing tip in new offset caused the tip to resize itself
-        var actualWidth = $tip[0].offsetWidth
-        var actualHeight = $tip[0].offsetHeight
-
-        if (placement == 'top' && actualHeight != height) {
-            offset.top = offset.top + height - actualHeight
-        }
-
-        var delta = this.getViewportAdjustedDelta(placement, offset, actualWidth, actualHeight)
-
-        if (delta.left) offset.left += delta.left
-        else offset.top += delta.top
-
-        var isVertical = /top|bottom/.test(placement)
-        var arrowDelta = isVertical ? delta.left * 2 - width + actualWidth : delta.top * 2 - height + actualHeight
-        var arrowOffsetPosition = isVertical ? 'offsetWidth' : 'offsetHeight'
-
-        $tip.offset(offset)
-        this.replaceArrow(arrowDelta, $tip[0][arrowOffsetPosition], isVertical)
-    }
-
-    Tooltip.prototype.replaceArrow = function (delta, dimension, isVertical) {
-        this.arrow()
-          .css(isVertical ? 'left' : 'top', 50 * (1 - delta / dimension) + '%')
-          .css(isVertical ? 'top' : 'left', '')
-    }
-
-    Tooltip.prototype.setContent = function () {
-        var $tip = this.tip()
-        var title = this.getTitle()
-
-        $tip.find('.tooltip-inner')[this.options.html ? 'html' : 'text'](title)
-        $tip.removeClass('fade in top bottom left right')
-    }
-
-    Tooltip.prototype.hide = function (callback) {
-        var that = this
-        var $tip = $(this.$tip)
-        var e = $.Event('hide.bs.' + this.type)
-
-        function complete() {
-            if (that.hoverState != 'in') $tip.detach()
-            that.$element
-              .removeAttr('aria-describedby')
-              .trigger('hidden.bs.' + that.type)
-            callback && callback()
-        }
-
-        this.$element.trigger(e)
-
-        if (e.isDefaultPrevented()) return
-
-        $tip.removeClass('in')
-
-        $.support.transition && $tip.hasClass('fade') ?
-          $tip
-            .one('bsTransitionEnd', complete)
-            .emulateTransitionEnd(Tooltip.TRANSITION_DURATION) :
-          complete()
-
-        this.hoverState = null
-
-        return this
-    }
-
-    Tooltip.prototype.fixTitle = function () {
-        var $e = this.$element
-        if ($e.attr('title') || typeof $e.attr('data-original-title') != 'string') {
-            $e.attr('data-original-title', $e.attr('title') || '').attr('title', '')
-        }
-    }
-
-    Tooltip.prototype.hasContent = function () {
-        return this.getTitle()
-    }
-
-    Tooltip.prototype.getPosition = function ($element) {
-        $element = $element || this.$element
-
-        var el = $element[0]
-        var isBody = el.tagName == 'BODY'
-
-        var elRect = el.getBoundingClientRect()
-        if (elRect.width == null) {
-            // width and height are missing in IE8, so compute them manually; see https://github.com/twbs/bootstrap/issues/14093
-            elRect = $.extend({}, elRect, { width: elRect.right - elRect.left, height: elRect.bottom - elRect.top })
-        }
-        var elOffset = isBody ? { top: 0, left: 0 } : $element.offset()
-        var scroll = { scroll: isBody ? document.documentElement.scrollTop || document.body.scrollTop : $element.scrollTop() }
-        var outerDims = isBody ? { width: $(window).width(), height: $(window).height() } : null
-
-        return $.extend({}, elRect, scroll, outerDims, elOffset)
-    }
-
-    Tooltip.prototype.getCalculatedOffset = function (placement, pos, actualWidth, actualHeight) {
-        return placement == 'bottom' ? { top: pos.top + pos.height, left: pos.left + pos.width / 2 - actualWidth / 2 } :
-               placement == 'top' ? { top: pos.top - actualHeight, left: pos.left + pos.width / 2 - actualWidth / 2 } :
-               placement == 'left' ? { top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left - actualWidth } :
-            /* placement == 'right' */ { top: pos.top + pos.height / 2 - actualHeight / 2, left: pos.left + pos.width }
-
-    }
-
-    Tooltip.prototype.getViewportAdjustedDelta = function (placement, pos, actualWidth, actualHeight) {
-        var delta = { top: 0, left: 0 }
-        if (!this.$viewport) return delta
-
-        var viewportPadding = this.options.viewport && this.options.viewport.padding || 0
-        var viewportDimensions = this.getPosition(this.$viewport)
-
-        if (/right|left/.test(placement)) {
-            var topEdgeOffset = pos.top - viewportPadding - viewportDimensions.scroll
-            var bottomEdgeOffset = pos.top + viewportPadding - viewportDimensions.scroll + actualHeight
-            if (topEdgeOffset < viewportDimensions.top) { // top overflow
-                delta.top = viewportDimensions.top - topEdgeOffset
-            } else if (bottomEdgeOffset > viewportDimensions.top + viewportDimensions.height) { // bottom overflow
-                delta.top = viewportDimensions.top + viewportDimensions.height - bottomEdgeOffset
-            }
-        } else {
-            var leftEdgeOffset = pos.left - viewportPadding
-            var rightEdgeOffset = pos.left + viewportPadding + actualWidth
-            if (leftEdgeOffset < viewportDimensions.left) { // left overflow
-                delta.left = viewportDimensions.left - leftEdgeOffset
-            } else if (rightEdgeOffset > viewportDimensions.right) { // right overflow
-                delta.left = viewportDimensions.left + viewportDimensions.width - rightEdgeOffset
-            }
-        }
-
-        return delta
-    }
-
-    Tooltip.prototype.getTitle = function () {
-        var title
-        var $e = this.$element
-        var o = this.options
-
-        title = $e.attr('data-original-title')
-          || (typeof o.title == 'function' ? o.title.call($e[0]) : o.title)
-
-        return title
-    }
-
-    Tooltip.prototype.getUID = function (prefix) {
-        do prefix += ~~(Math.random() * 1000000)
-        while (document.getElementById(prefix))
-        return prefix
-    }
-
-    Tooltip.prototype.tip = function () {
-        if (!this.$tip) {
-            this.$tip = $(this.options.template)
-            if (this.$tip.length != 1) {
-                throw new Error(this.type + ' `template` option must consist of exactly 1 top-level element!')
-            }
-        }
-        return this.$tip
-    }
-
-    Tooltip.prototype.arrow = function () {
-        return (this.$arrow = this.$arrow || this.tip().find('.tooltip-arrow'))
-    }
-
-    Tooltip.prototype.enable = function () {
-        this.enabled = true
-    }
-
-    Tooltip.prototype.disable = function () {
-        this.enabled = false
-    }
-
-    Tooltip.prototype.toggleEnabled = function () {
-        this.enabled = !this.enabled
-    }
-
-    Tooltip.prototype.toggle = function (e) {
-        var self = this
-        if (e) {
-            self = $(e.currentTarget).data('bs.' + this.type)
-            if (!self) {
-                self = new this.constructor(e.currentTarget, this.getDelegateOptions())
-                $(e.currentTarget).data('bs.' + this.type, self)
-            }
-        }
-
-        if (e) {
-            self.inState.click = !self.inState.click
-            if (self.isInStateTrue()) self.enter(self)
-            else self.leave(self)
-        } else {
-            self.tip().hasClass('in') ? self.leave(self) : self.enter(self)
-        }
-    }
-
-    Tooltip.prototype.destroy = function () {
-        var that = this
-        clearTimeout(this.timeout)
-        this.hide(function () {
-            that.$element.off('.' + that.type).removeData('bs.' + that.type)
-            if (that.$tip) {
-                that.$tip.detach()
-            }
-            that.$tip = null
-            that.$arrow = null
-            that.$viewport = null
-        })
-    }
+  Tooltip.prototype.destroy = function () {
+    var that = this
+    clearTimeout(this.timeout)
+    this.hide(function () {
+      that.$element.off('.' + that.type).removeData('bs.' + that.type)
+      if (that.$tip) {
+        that.$tip.detach()
+      }
+      that.$tip = null
+      that.$arrow = null
+      that.$viewport = null
+    })
+  }
 
 
-    // TOOLTIP PLUGIN DEFINITION
-    // =========================
+  // TOOLTIP PLUGIN DEFINITION
+  // =========================
 
-    function Plugin(option) {
-        return this.each(function () {
-            var $this = $(this)
-            var data = $this.data('bs.tooltip')
-            var options = typeof option == 'object' && option
+  function Plugin(option) {
+    return this.each(function () {
+      var $this   = $(this)
+      var data    = $this.data('bs.tooltip')
+      var options = typeof option == 'object' && option
 
-            if (!data && /destroy|hide/.test(option)) return
-            if (!data) $this.data('bs.tooltip', (data = new Tooltip(this, options)))
-            if (typeof option == 'string') data[option]()
-        })
-    }
+      if (!data && /destroy|hide/.test(option)) return
+      if (!data) $this.data('bs.tooltip', (data = new Tooltip(this, options)))
+      if (typeof option == 'string') data[option]()
+    })
+  }
 
-    var old = $.fn.tooltip
+  var old = $.fn.tooltip
 
-    $.fn.tooltip = Plugin
-    $.fn.tooltip.Constructor = Tooltip
+  $.fn.tooltip             = Plugin
+  $.fn.tooltip.Constructor = Tooltip
 
 
-    // TOOLTIP NO CONFLICT
-    // ===================
+  // TOOLTIP NO CONFLICT
+  // ===================
 
-    $.fn.tooltip.noConflict = function () {
-        $.fn.tooltip = old
-        return this
-    }
+  $.fn.tooltip.noConflict = function () {
+    $.fn.tooltip = old
+    return this
+  }
 
 }(jQuery);
 
 
-// GENERAL UTILITY FUNCTIONS
-// ===============================
+  // GENERAL UTILITY FUNCTIONS
+  // ===============================
+  
+  var uniqueId = function(prefix) {
+      return (prefix || 'ui-id') + '-' + Math.floor((Math.random()*1000)+1)
+  }
 
-var uniqueId = function (prefix) {
-    return (prefix || 'ui-id') + '-' + Math.floor((Math.random() * 1000) + 1)
-}
-
-
-var removeMultiValAttributes = function (el, attr, val) {
-    var describedby = (el.attr(attr) || "").split(/\s+/)
-       , index = $.inArray(val, describedby)
-    if (index !== -1) {
-        describedby.splice(index, 1)
-    }
-    describedby = $.trim(describedby.join(" "))
-    if (describedby) {
-        el.attr(attr, describedby)
-    } else {
-        el.removeAttr(attr)
-    }
-}
-// DROPDOWN Extension
-// ===============================
-
-var toggle = '[data-toggle=dropdown]'
-    , $par
-    , firstItem
-    , focusDelay = 200
-    , menus = $(toggle).parent().find('ul').attr('role', 'menu')
-    , lis = menus.find('li').attr('role', 'presentation')
-
-lis.find('a').attr({ 'role': 'menuitem', 'tabIndex': '-1' })
-$(toggle).attr({ 'aria-haspopup': 'true', 'aria-expanded': 'false' })
-
-$(toggle).parent().on('shown.bs.dropdown', function (e) {
-    $par = $(this)
-    var $toggle = $par.find(toggle)
-    $toggle.attr('aria-expanded', 'true')
-
-    setTimeout(function () {
-        firstItem = $('.dropdown-menu [role=menuitem]:visible', $par)[0]
-        try { firstItem.focus() } catch (ex) { }
-    }, focusDelay)
-})
-
-$(toggle).parent().on('hidden.bs.dropdown', function (e) {
-    $par = $(this)
-    var $toggle = $par.find(toggle)
-    $toggle.attr('aria-expanded', 'false')
-})
-
-//Adding Space Key Behaviour, opens on spacebar
-$.fn.dropdown.Constructor.prototype.keydown = function (e) {
-    var $par
+  
+  var removeMultiValAttributes = function (el, attr, val) {
+   var describedby = (el.attr( attr ) || "").split( /\s+/ )
+      , index = $.inArray(val, describedby)
+   if ( index !== -1 ) {
+     describedby.splice( index, 1 )
+   }
+   describedby = $.trim( describedby.join( " " ) )
+   if (describedby ) {
+     el.attr( attr, describedby )
+   } else {
+    el.removeAttr( attr )
+   }
+  }
+  // DROPDOWN Extension
+  // ===============================
+  
+  var toggle   = '[data-toggle=dropdown]'
+      , $par
       , firstItem
-    if (!/(32)/.test(e.keyCode)) return
-    $par = $(this).parent()
-    $(this).trigger("click")
-    e.preventDefault() && e.stopPropagation()
-}
+      , focusDelay = 200
+      , menus = $(toggle).parent().find('ul').attr('role','menu')
+      , lis = menus.find('li').attr('role','presentation')
 
-$(document)
-  .on('focusout.dropdown.data-api', '.dropdown-menu', function (e) {
-      var $this = $(this)
-                  , that = this
-      setTimeout(function () {
-          if (!$.contains(that, document.activeElement)) {
-              $this.parent().removeClass('open')
-              $this.parent().find('[data-toggle=dropdown]').attr('aria-expanded', 'false')
-          }
-      }, 150)
-  })
-  .on('keydown.bs.dropdown.data-api', toggle + ', [role=menu]', $.fn.dropdown.Constructor.prototype.keydown)
-// Tab Extension
-// ===============================
+    lis.find('a').attr({'role':'menuitem', 'tabIndex':'-1'})
+    $(toggle).attr({ 'aria-haspopup':'true', 'aria-expanded': 'false'})
 
-var $tablist = $('.nav-tabs, .nav-pills')
-      , $lis = $tablist.children('li')
-      , $tabs = $tablist.find('[data-toggle="tab"], [data-toggle="pill"]')
+    $(toggle).parent().on('shown.bs.dropdown',function(e){
+      $par = $(this)
+      var $toggle = $par.find(toggle)
+      $toggle.attr('aria-expanded','true')
 
-$tablist.attr('role', 'tablist')
-$lis.attr('role', 'presentation')
-$tabs.attr('role', 'tab')
+      setTimeout(function(){
+            firstItem = $('.dropdown-menu [role=menuitem]:visible', $par)[0]
+            try{ firstItem.focus()} catch(ex) {}
+      }, focusDelay)
+    })
 
-$tabs.each(function (index) {
-    var tabpanel = $($(this).attr('href'))
-      , tab = $(this)
-      , tabid = tab.attr('id') || uniqueId('ui-tab')
+    $(toggle).parent().on('hidden.bs.dropdown',function(e){
+      $par = $(this)
+      var $toggle = $par.find(toggle)
+      $toggle.attr('aria-expanded','false')
+    })
 
-    tab.attr('id', tabid)
-
-    if (tab.parent().hasClass('active')) {
-        tab.attr({ 'tabIndex': '0', 'aria-selected': 'true', 'aria-controls': tab.attr('href').substr(1) })
-        tabpanel.attr({ 'role': 'tabpanel', 'tabIndex': '0', 'aria-hidden': 'false', 'aria-labelledby': tabid })
-    } else {
-        tab.attr({ 'tabIndex': '-1', 'aria-selected': 'false', 'aria-controls': tab.attr('href').substr(1) })
-        tabpanel.attr({ 'role': 'tabpanel', 'tabIndex': '-1', 'aria-hidden': 'true', 'aria-labelledby': tabid })
+    //Adding Space Key Behaviour, opens on spacebar
+    $.fn.dropdown.Constructor.prototype.keydown = function (e) {
+      var  $par
+        , firstItem
+      if (!/(32)/.test(e.keyCode)) return
+        $par = $(this).parent()
+        $(this).trigger ("click")
+        e.preventDefault() && e.stopPropagation()
     }
-})
 
-$.fn.tab.Constructor.prototype.keydown = function (e) {
-    var $this = $(this)
-    , $items
-    , $ul = $this.closest('ul[role=tablist] ')
-    , index
-    , k = e.which || e.keyCode
+    $(document)
+      .on('focusout.dropdown.data-api', '.dropdown-menu', function(e){
+        var $this = $(this)
+                    , that = this
+        setTimeout(function() {
+         if(!$.contains(that, document.activeElement)){
+          $this.parent().removeClass('open')
+          $this.parent().find('[data-toggle=dropdown]').attr('aria-expanded','false')
+         }
+        }, 150)
+       })
+      .on('keydown.bs.dropdown.data-api', toggle + ', [role=menu]' , $.fn.dropdown.Constructor.prototype.keydown)
+  // Tab Extension
+  // ===============================
+  
+  var $tablist = $('.nav-tabs, .nav-pills')
+        , $lis = $tablist.children('li')
+        , $tabs = $tablist.find('[data-toggle="tab"], [data-toggle="pill"]')
 
-    $this = $(this)
-    if (!/(37|38|39|40)/.test(k)) return
+    $tablist.attr('role', 'tablist')
+    $lis.attr('role', 'presentation')
+    $tabs.attr('role', 'tab')
 
-    $items = $ul.find('[role=tab]:visible')
-    index = $items.index($items.filter(':focus'))
+    $tabs.each(function( index ) {
+      var tabpanel = $($(this).attr('href'))
+        , tab = $(this)
+        , tabid = tab.attr('id') || uniqueId('ui-tab')
 
-    if (k == 38 || k == 37) index--                         // up & left
-    if (k == 39 || k == 40) index++                        // down & right
+        tab.attr('id', tabid)
+
+      if(tab.parent().hasClass('active')){
+        tab.attr( { 'tabIndex' : '0', 'aria-selected' : 'true', 'aria-controls': tab.attr('href').substr(1) } )
+        tabpanel.attr({ 'role' : 'tabpanel', 'tabIndex' : '0', 'aria-hidden' : 'false', 'aria-labelledby':tabid })
+      }else{
+        tab.attr( { 'tabIndex' : '-1', 'aria-selected' : 'false', 'aria-controls': tab.attr('href').substr(1) } )
+        tabpanel.attr( { 'role' : 'tabpanel', 'tabIndex' : '-1', 'aria-hidden' : 'true', 'aria-labelledby':tabid } )
+      }
+    })
+
+    $.fn.tab.Constructor.prototype.keydown = function (e) {
+      var $this = $(this)
+      , $items
+      , $ul = $this.closest('ul[role=tablist] ')
+      , index
+      , k = e.which || e.keyCode
+
+      $this = $(this)
+      if (!/(37|38|39|40)/.test(k)) return
+
+      $items = $ul.find('[role=tab]:visible')
+      index = $items.index($items.filter(':focus'))
+
+      if (k == 38 || k == 37) index--                         // up & left
+      if (k == 39 || k == 40) index++                        // down & right
 
 
-    if (index < 0) index = $items.length - 1
-    if (index == $items.length) index = 0
+      if(index < 0) index = $items.length -1
+      if(index == $items.length) index = 0
 
-    var nextTab = $items.eq(index)
-    if (nextTab.attr('role') === 'tab') {
+      var nextTab = $items.eq(index)
+      if(nextTab.attr('role') ==='tab'){
 
         nextTab.tab('show')      //Comment this line for dynamically loaded tabPabels, to save Ajax requests on arrow key navigation
         .focus()
+      }
+      // nextTab.focus()
+
+      e.preventDefault()
+      e.stopPropagation()
     }
-    // nextTab.focus()
 
-    e.preventDefault()
-    e.stopPropagation()
-}
+    $(document).on('keydown.tab.data-api','[data-toggle="tab"], [data-toggle="pill"]' , $.fn.tab.Constructor.prototype.keydown)
 
-$(document).on('keydown.tab.data-api', '[data-toggle="tab"], [data-toggle="pill"]', $.fn.tab.Constructor.prototype.keydown)
+   var tabactivate =    $.fn.tab.Constructor.prototype.activate;
+   $.fn.tab.Constructor.prototype.activate = function (element, container, callback) {
+      var $active = container.find('> .active')
+      $active.find('[data-toggle=tab], [data-toggle=pill]').attr({ 'tabIndex' : '-1','aria-selected' : false })
+      $active.filter('.tab-pane').attr({ 'aria-hidden' : true,'tabIndex' : '-1' })
 
-var tabactivate = $.fn.tab.Constructor.prototype.activate;
-$.fn.tab.Constructor.prototype.activate = function (element, container, callback) {
-    var $active = container.find('> .active')
-    $active.find('[data-toggle=tab], [data-toggle=pill]').attr({ 'tabIndex': '-1', 'aria-selected': false })
-    $active.filter('.tab-pane').attr({ 'aria-hidden': true, 'tabIndex': '-1' })
+      tabactivate.apply(this, arguments)
 
-    tabactivate.apply(this, arguments)
+      element.addClass('active')
+      element.find('[data-toggle=tab], [data-toggle=pill]').attr({ 'tabIndex' : '0','aria-selected' : true })
+      element.filter('.tab-pane').attr({ 'aria-hidden' : false,'tabIndex' : '0' })
+   }
+var fakewaffle = ( function ( $, fakewaffle ) {
+  'use strict';
 
-    element.addClass('active')
-    element.find('[data-toggle=tab], [data-toggle=pill]').attr({ 'tabIndex': '0', 'aria-selected': true })
-    element.filter('.tab-pane').attr({ 'aria-hidden': false, 'tabIndex': '0' })
-}
-var fakewaffle = (function ($, fakewaffle) {
-    'use strict';
+  var _id= 0;
 
-    var _id = 0;
+  fakewaffle.responsiveTabs = function ( collapseDisplayed ) {
 
-    fakewaffle.responsiveTabs = function (collapseDisplayed) {
+    fakewaffle.currentPosition = 'tabs';
 
-        fakewaffle.currentPosition = 'tabs';
+    var tabGroups = $( '.nav-tabs.responsive, .nav-pills.responsive' );
+    var hidden    = '';
+    var visible   = '';
+    var activeTab = '';
 
-        var tabGroups = $('.nav-tabs.responsive, .nav-pills.responsive');
-        var hidden = '';
-        var visible = '';
-        var activeTab = '';
+    if ( collapseDisplayed === undefined ) {
+      collapseDisplayed = [ 'xs', 'sm' ];
+    }
 
-        if (collapseDisplayed === undefined) {
-            collapseDisplayed = ['xs', 'sm'];
+    $.each( collapseDisplayed, function () {
+      hidden  += ' hidden-' + this;
+      visible += ' visible-' + this;
+    } );
+
+    $.each( tabGroups, function () {
+      var $tabGroup   = $( this );
+      var tabs        = $tabGroup.find( '[data-toggle="tab"]' );
+      var collapseDiv = $( '<div></div>', {
+        'class' : 'panel-group responsive' + visible,
+        'id'    : 'collapse-' + +'waffle-' + (_id++)
+      } );
+
+      $.each( tabs, function () {
+        var $this          = $( this );
+        var oldLinkClass   = $this.attr( 'class' ) === undefined ? '' : $this.attr( 'class' );
+        var newLinkClass   = 'accordion-toggle collapsed';
+        var oldParentClass = $this.parent().attr( 'class' ) === undefined ? '' : $this.parent().attr( 'class' );
+        var newParentClass = 'panel panel-default';
+        var newHash        = $this.get( 0 ).hash.replace( '#', 'collapse-' );
+
+        if ( oldLinkClass.length > 0 ) {
+          newLinkClass += ' ' + oldLinkClass;
         }
 
-        $.each(collapseDisplayed, function () {
-            hidden += ' hidden-' + this;
-            visible += ' visible-' + this;
-        });
-
-        $.each(tabGroups, function () {
-            var $tabGroup = $(this);
-            var tabs = $tabGroup.find('[data-toggle="tab"]');
-            var collapseDiv = $('<div></div>', {
-                'class': 'panel-group responsive' + visible,
-                'id': 'collapse-' + +'waffle-' + (_id++)
-            });
-
-            $.each(tabs, function () {
-                var $this = $(this);
-                var oldLinkClass = $this.attr('class') === undefined ? '' : $this.attr('class');
-                var newLinkClass = 'accordion-toggle collapsed';
-                var oldParentClass = $this.parent().attr('class') === undefined ? '' : $this.parent().attr('class');
-                var newParentClass = 'panel panel-default';
-                var newHash = $this.get(0).hash.replace('#', 'collapse-');
-
-                if (oldLinkClass.length > 0) {
-                    newLinkClass += ' ' + oldLinkClass;
-                }
-
-                if (oldParentClass.length > 0) {
-                    oldParentClass = oldParentClass.replace(/\bactive\b/g, '');
-                    newParentClass += ' ' + oldParentClass;
-                    newParentClass = newParentClass.replace(/\s{2,}/g, ' ');
-                    newParentClass = newParentClass.replace(/^\s+|\s+$/g, '');
-                }
-
-                if ($this.parent().hasClass('active')) {
-                    activeTab = '#' + newHash;
-                }
-
-                collapseDiv.append(
-                  $('<div>').attr('class', newParentClass).html(
-                    $('<div>').attr('class', 'panel-heading').html(
-                      $('<h4>').attr('class', 'panel-title').html(
-                        $('<a>', {
-                            'class': newLinkClass,
-                            'data-toggle': 'collapse',
-                            'data-parent': '#collapse-' + $tabGroup.attr('id'),
-                            'href': '#' + newHash,
-                            'html': $this.html()
-                        })
-                      )
-                    )
-                  ).append(
-                    $('<div>', {
-                        'id': newHash,
-                        'class': 'panel-collapse collapse'
-                    })
-                  )
-                );
-            });
-
-            $tabGroup.next().after(collapseDiv);
-            $tabGroup.addClass(hidden);
-            $('.tab-content.responsive').addClass(hidden);
-        });
-
-
-        fakewaffle.checkResize();
-        fakewaffle.bindTabToCollapse();
-
-        if (activeTab) {
-            $(activeTab).collapse('show');
-        }
-    };
-
-    fakewaffle.checkResize = function () {
-
-        if ($('.panel-group.responsive').is(':visible') === true && fakewaffle.currentPosition === 'tabs') {
-            fakewaffle.tabToPanel();
-            fakewaffle.currentPosition = 'panel';
-        } else if ($('.panel-group.responsive').is(':visible') === false && fakewaffle.currentPosition === 'panel') {
-            fakewaffle.panelToTab();
-            fakewaffle.currentPosition = 'tabs';
+        if ( oldParentClass.length > 0 ) {
+          oldParentClass = oldParentClass.replace( /\bactive\b/g, '' );
+          newParentClass += ' ' + oldParentClass;
+          newParentClass = newParentClass.replace( /\s{2,}/g, ' ' );
+          newParentClass = newParentClass.replace( /^\s+|\s+$/g, '' );
         }
 
-    };
+        if ( $this.parent().hasClass( 'active' ) ) {
+          activeTab = '#' + newHash;
+        }
 
-    fakewaffle.tabToPanel = function () {
+        collapseDiv.append(
+          $( '<div>' ).attr( 'class', newParentClass ).html(
+            $( '<div>' ).attr( 'class', 'panel-heading' ).html(
+              $( '<h4>' ).attr( 'class', 'panel-title' ).html(
+                $( '<a>', {
+                  'class'       : newLinkClass,
+                  'data-toggle' : 'collapse',
+                  'data-parent' : '#collapse-' + $tabGroup.attr( 'id' ),
+                  'href'        : '#' + newHash,
+                  'html'        : $this.html()
+                } )
+              )
+            )
+          ).append(
+            $( '<div>', {
+              'id'    : newHash,
+              'class' : 'panel-collapse collapse'
+            } )
+          )
+        );
+      } );
 
-        var tabGroups = $('.nav-tabs.responsive, .nav-pills.responsive');
+      $tabGroup.next().after( collapseDiv );
+      $tabGroup.addClass( hidden );
+      $( '.tab-content.responsive' ).addClass( hidden );
+    } );
 
-        $.each(tabGroups, function (index, tabGroup) {
 
-            // Find the tab
-            var tabContents = $(tabGroup).next('.tab-content').find('.tab-pane');
+    fakewaffle.checkResize();
+    fakewaffle.bindTabToCollapse();
 
-            $.each(tabContents, function (index, tabContent) {
-                // Find the id to move the element to
-                var destinationId = $(tabContent).attr('id').replace(/^/, '#collapse-');
+    if ( activeTab ) {
+      $( activeTab ).collapse( 'show' );
+    }
+  };
 
-                // Convert tab to panel and move to destination
-                $(tabContent)
-                  .removeClass('tab-pane')
-                  .addClass('panel-body')
-                  .appendTo($(destinationId));
+  fakewaffle.checkResize = function () {
 
-            });
+    if ( $( '.panel-group.responsive' ).is( ':visible' ) === true && fakewaffle.currentPosition === 'tabs' ) {
+      fakewaffle.tabToPanel();
+      fakewaffle.currentPosition = 'panel';
+    } else if ( $( '.panel-group.responsive' ).is( ':visible' ) === false && fakewaffle.currentPosition === 'panel' ) {
+      fakewaffle.panelToTab();
+      fakewaffle.currentPosition = 'tabs';
+    }
 
-        });
+  };
 
-    };
+  fakewaffle.tabToPanel = function () {
 
-    fakewaffle.panelToTab = function () {
+    var tabGroups = $( '.nav-tabs.responsive, .nav-pills.responsive' );
 
-        var panelGroups = $('.panel-group.responsive');
+    $.each( tabGroups, function ( index, tabGroup ) {
 
-        $.each(panelGroups, function (index, panelGroup) {
+      // Find the tab
+      var tabContents = $( tabGroup ).next( '.tab-content' ).find( '.tab-pane' );
 
-            var destinationId = $(panelGroup).attr('id').replace('collapse-', '#');
-            var destination = $(destinationId).next('.tab-content')[0];
+      $.each( tabContents, function ( index, tabContent ) {
+        // Find the id to move the element to
+        var destinationId = $( tabContent ).attr( 'id' ).replace ( /^/, '#collapse-' );
 
-            // Find the panel contents
-            var panelContents = $(panelGroup).find('.panel-body');
+        // Convert tab to panel and move to destination
+        $( tabContent )
+          .removeClass( 'tab-pane' )
+          .addClass( 'panel-body' )
+          .appendTo( $( destinationId ) );
 
-            // Convert to tab and move to destination
-            panelContents
-              .removeClass('panel-body')
-              .addClass('tab-pane')
-              .appendTo($(destination));
+      } );
 
-        });
+    } );
 
-    };
+  };
 
-    fakewaffle.bindTabToCollapse = function () {
+  fakewaffle.panelToTab = function () {
 
-        var tabs = $('.nav-tabs.responsive, .nav-pills.responsive').find('li a');
-        var collapse = $('.panel-group.responsive').find('.panel-collapse');
+    var panelGroups = $( '.panel-group.responsive' );
 
-        // Toggle the panels when the associated tab is toggled
-        tabs.on('shown.bs.tab', function (e) {
-            var $current = $(e.currentTarget.hash.replace(/#/, '#collapse-'));
-            $current.collapse('show');
+    $.each( panelGroups, function ( index, panelGroup ) {
 
-            if (e.relatedTarget) {
-                var $previous = $(e.relatedTarget.hash.replace(/#/, '#collapse-'));
-                $previous.collapse('hide');
-            }
-        });
+      var destinationId = $( panelGroup ).attr( 'id' ).replace( 'collapse-', '#' );
+      var destination   = $( destinationId ).next( '.tab-content' )[ 0 ];
 
-        // Toggle the tab when the associated panel is toggled
-        collapse.on('shown.bs.collapse', function (e) {
+      // Find the panel contents
+      var panelContents = $( panelGroup ).find( '.panel-body' );
 
-            // Activate current tabs
-            var current = $(e.target).context.id.replace(/collapse-/g, '#');
-            $('a[href="' + current + '"]').tab('show');
+      // Convert to tab and move to destination
+      panelContents
+        .removeClass( 'panel-body' )
+        .addClass( 'tab-pane' )
+        .appendTo( $( destination ) );
 
-            // Update the content with active
-            var panelGroup = $(e.currentTarget).closest('.panel-group.responsive');
-            $(panelGroup).find('.panel-body').removeClass('active');
-            $(e.currentTarget).find('.panel-body').addClass('active');
+    } );
 
-        });
-    };
+  };
 
-    $(window).resize(function () {
-        fakewaffle.checkResize();
-    });
+  fakewaffle.bindTabToCollapse = function () {
 
-    return fakewaffle;
-}(window.jQuery, fakewaffle || {}));
+    var tabs     = $( '.nav-tabs.responsive, .nav-pills.responsive' ).find( 'li a' );
+    var collapse = $( '.panel-group.responsive' ).find( '.panel-collapse' );
+
+    // Toggle the panels when the associated tab is toggled
+    tabs.on( 'shown.bs.tab', function ( e ) {
+      var $current  = $( e.currentTarget.hash.replace( /#/, '#collapse-' ) );
+      $current.collapse( 'show' );
+
+      if ( e.relatedTarget ) {
+        var $previous = $( e.relatedTarget.hash.replace( /#/, '#collapse-' ) );
+        $previous.collapse( 'hide' );
+      }
+    } );
+
+    // Toggle the tab when the associated panel is toggled
+    collapse.on( 'shown.bs.collapse', function ( e ) {
+
+      // Activate current tabs
+      var current = $( e.target ).context.id.replace( /collapse-/g, '#' );
+      $( 'a[href="' + current + '"]' ).tab( 'show' );
+
+      // Update the content with active
+      var panelGroup = $( e.currentTarget ).closest( '.panel-group.responsive' );
+      $( panelGroup ).find( '.panel-body' ).removeClass( 'active' );
+      $( e.currentTarget ).find( '.panel-body' ).addClass( 'active' );
+
+    } );
+  };
+
+  $( window ).resize( function () {
+    fakewaffle.checkResize();
+  } );
+
+  return fakewaffle;
+}( window.jQuery, fakewaffle || { } ) );
 
 /**
  * Owl carousel
@@ -2007,1649 +2007,1649 @@ var fakewaffle = (function ($, fakewaffle) {
  * @todo Test Zepto
  * @todo stagePadding calculate wrong active classes
  */
-; (function ($, window, document, undefined) {
+;(function($, window, document, undefined) {
+
+  /**
+   * Creates a carousel.
+   * @class The Owl Carousel.
+   * @public
+   * @param {HTMLElement|jQuery} element - The element to create the carousel for.
+   * @param {Object} [options] - The options
+   */
+  function Owl(element, options) {
 
     /**
-     * Creates a carousel.
-     * @class The Owl Carousel.
+     * Current settings for the carousel.
      * @public
-     * @param {HTMLElement|jQuery} element - The element to create the carousel for.
-     * @param {Object} [options] - The options
      */
-    function Owl(element, options) {
+    this.settings = null;
 
-        /**
-         * Current settings for the carousel.
-         * @public
-         */
-        this.settings = null;
+    /**
+     * Current options set by the caller including defaults.
+     * @public
+     */
+    this.options = $.extend({}, Owl.Defaults, options);
 
-        /**
-         * Current options set by the caller including defaults.
-         * @public
-         */
-        this.options = $.extend({}, Owl.Defaults, options);
+    /**
+     * Plugin element.
+     * @public
+     */
+    this.$element = $(element);
 
-        /**
-         * Plugin element.
-         * @public
-         */
-        this.$element = $(element);
+    /**
+     * Proxied event handlers.
+     * @protected
+     */
+    this._handlers = {};
 
-        /**
-         * Proxied event handlers.
-         * @protected
-         */
-        this._handlers = {};
+    /**
+     * References to the running plugins of this carousel.
+     * @protected
+     */
+    this._plugins = {};
 
-        /**
-         * References to the running plugins of this carousel.
-         * @protected
-         */
-        this._plugins = {};
+    /**
+     * Currently suppressed events to prevent them from beeing retriggered.
+     * @protected
+     */
+    this._supress = {};
 
-        /**
-         * Currently suppressed events to prevent them from beeing retriggered.
-         * @protected
-         */
-        this._supress = {};
+    /**
+     * Absolute current position.
+     * @protected
+     */
+    this._current = null;
 
-        /**
-         * Absolute current position.
-         * @protected
-         */
-        this._current = null;
+    /**
+     * Animation speed in milliseconds.
+     * @protected
+     */
+    this._speed = null;
 
-        /**
-         * Animation speed in milliseconds.
-         * @protected
-         */
-        this._speed = null;
+    /**
+     * Coordinates of all items in pixel.
+     * @todo The name of this member is missleading.
+     * @protected
+     */
+    this._coordinates = [];
 
-        /**
-         * Coordinates of all items in pixel.
-         * @todo The name of this member is missleading.
-         * @protected
-         */
-        this._coordinates = [];
+    /**
+     * Current breakpoint.
+     * @todo Real media queries would be nice.
+     * @protected
+     */
+    this._breakpoint = null;
 
-        /**
-         * Current breakpoint.
-         * @todo Real media queries would be nice.
-         * @protected
-         */
-        this._breakpoint = null;
+    /**
+     * Current width of the plugin element.
+     */
+    this._width = null;
 
-        /**
-         * Current width of the plugin element.
-         */
-        this._width = null;
+    /**
+     * All real items.
+     * @protected
+     */
+    this._items = [];
 
-        /**
-         * All real items.
-         * @protected
-         */
-        this._items = [];
+    /**
+     * All cloned items.
+     * @protected
+     */
+    this._clones = [];
 
-        /**
-         * All cloned items.
-         * @protected
-         */
-        this._clones = [];
+    /**
+     * Merge values of all items.
+     * @todo Maybe this could be part of a plugin.
+     * @protected
+     */
+    this._mergers = [];
 
-        /**
-         * Merge values of all items.
-         * @todo Maybe this could be part of a plugin.
-         * @protected
-         */
-        this._mergers = [];
+    /**
+     * Widths of all items.
+     */
+    this._widths = [];
 
-        /**
-         * Widths of all items.
-         */
-        this._widths = [];
+    /**
+     * Invalidated parts within the update process.
+     * @protected
+     */
+    this._invalidated = {};
 
-        /**
-         * Invalidated parts within the update process.
-         * @protected
-         */
-        this._invalidated = {};
+    /**
+     * Ordered list of workers for the update process.
+     * @protected
+     */
+    this._pipe = [];
 
-        /**
-         * Ordered list of workers for the update process.
-         * @protected
-         */
-        this._pipe = [];
+    /**
+     * Current state information for the drag operation.
+     * @todo #261
+     * @protected
+     */
+    this._drag = {
+      time: null,
+      target: null,
+      pointer: null,
+      stage: {
+        start: null,
+        current: null
+      },
+      direction: null
+    };
 
-        /**
-         * Current state information for the drag operation.
-         * @todo #261
-         * @protected
-         */
-        this._drag = {
-            time: null,
-            target: null,
-            pointer: null,
-            stage: {
-                start: null,
-                current: null
-            },
-            direction: null
+    /**
+     * Current state information and their tags.
+     * @type {Object}
+     * @protected
+     */
+    this._states = {
+      current: {},
+      tags: {
+        'initializing': [ 'busy' ],
+        'animating': [ 'busy' ],
+        'dragging': [ 'interacting' ]
+      }
+    };
+
+    $.each([ 'onResize', 'onThrottledResize' ], $.proxy(function(i, handler) {
+      this._handlers[handler] = $.proxy(this[handler], this);
+    }, this));
+
+    $.each(Owl.Plugins, $.proxy(function(key, plugin) {
+      this._plugins[key.charAt(0).toLowerCase() + key.slice(1)]
+        = new plugin(this);
+    }, this));
+
+    $.each(Owl.Workers, $.proxy(function(priority, worker) {
+      this._pipe.push({
+        'filter': worker.filter,
+        'run': $.proxy(worker.run, this)
+      });
+    }, this));
+
+    this.setup();
+    this.initialize();
+  }
+
+  /**
+   * Default options for the carousel.
+   * @public
+   */
+  Owl.Defaults = {
+    items: 3,
+	autoplay: false,
+	autoplauhoverpause: true,
+    loop: true,
+    center: false,
+    rewind: false,
+
+    mouseDrag: true,
+    touchDrag: true,
+    pullDrag: true,
+    freeDrag: false,
+
+    margin: 0,
+    stagePadding: 0,
+
+    merge: false,
+    mergeFit: true,
+    autoWidth: false,
+
+    startPosition: 0,
+    rtl: false,
+
+    smartSpeed: 250,
+    fluidSpeed: false,
+    dragEndSpeed: false,
+
+    responsive: {},
+    responsiveRefreshRate: 200,
+    responsiveBaseElement: window,
+
+    fallbackEasing: 'swing',
+
+    info: false,
+
+    nestedItemSelector: false,
+    itemElement: 'div',
+    stageElement: 'div',
+
+    refreshClass: 'owl-refresh',
+    loadedClass: 'owl-loaded',
+    loadingClass: 'owl-loading',
+    rtlClass: 'owl-rtl',
+    responsiveClass: 'owl-responsive',
+    dragClass: 'owl-drag',
+    itemClass: 'owl-item',
+    stageClass: 'owl-stage',
+    stageOuterClass: 'owl-stage-outer',
+    grabClass: 'owl-grab'
+  };
+
+  /**
+   * Enumeration for width.
+   * @public
+   * @readonly
+   * @enum {String}
+   */
+  Owl.Width = {
+    Default: 'default',
+    Inner: 'inner',
+    Outer: 'outer'
+  };
+
+  /**
+   * Enumeration for types.
+   * @public
+   * @readonly
+   * @enum {String}
+   */
+  Owl.Type = {
+    Event: 'event',
+    State: 'state'
+  };
+
+  /**
+   * Contains all registered plugins.
+   * @public
+   */
+  Owl.Plugins = {};
+
+  /**
+   * List of workers involved in the update process.
+   */
+  Owl.Workers = [ {
+    filter: [ 'width', 'settings' ],
+    run: function() {
+      this._width = this.$element.width();
+    }
+  }, {
+    filter: [ 'width', 'items', 'settings' ],
+    run: function(cache) {
+      cache.current = this._items && this._items[this.relative(this._current)];
+    }
+  }, {
+    filter: [ 'items', 'settings' ],
+    run: function() {
+      this.$stage.children('.cloned').remove();
+    }
+  }, {
+    filter: [ 'width', 'items', 'settings' ],
+    run: function(cache) {
+      var margin = this.settings.margin || '',
+        grid = !this.settings.autoWidth,
+        rtl = this.settings.rtl,
+        css = {
+          'width': 'auto',
+          'margin-left': rtl ? margin : '',
+          'margin-right': rtl ? '' : margin
         };
 
-        /**
-         * Current state information and their tags.
-         * @type {Object}
-         * @protected
-         */
-        this._states = {
-            current: {},
-            tags: {
-                'initializing': ['busy'],
-                'animating': ['busy'],
-                'dragging': ['interacting']
-            }
+      !grid && this.$stage.children().css(css);
+
+      cache.css = css;
+    }
+  }, {
+    filter: [ 'width', 'items', 'settings' ],
+    run: function(cache) {
+      var width = (this.width() / this.settings.items).toFixed(3) - this.settings.margin,
+        merge = null,
+        iterator = this._items.length,
+        grid = !this.settings.autoWidth,
+        widths = [];
+
+      cache.items = {
+        merge: false,
+        width: width
+      };
+
+      while (iterator--) {
+        merge = this._mergers[iterator];
+        merge = this.settings.mergeFit && Math.min(merge, this.settings.items) || merge;
+
+        cache.items.merge = merge > 1 || cache.items.merge;
+
+        widths[iterator] = !grid ? this._items[iterator].width() : width * merge;
+      }
+
+      this._widths = widths;
+    }
+  }, {
+    filter: [ 'items', 'settings' ],
+    run: function() {
+      var clones = [],
+        items = this._items,
+        settings = this.settings,
+        view = Math.max(settings.items * 2, 4),
+        size = Math.ceil(items.length / 2) * 2,
+        repeat = settings.loop && items.length ? settings.rewind ? view : Math.max(view, size) : 0,
+        append = '',
+        prepend = '';
+
+      repeat /= 2;
+
+      while (repeat--) {
+        clones.push(this.normalize(clones.length / 2, true));
+        append = append + items[clones[clones.length - 1]][0].outerHTML;
+        clones.push(this.normalize(items.length - 1 - (clones.length - 1) / 2, true));
+        prepend = items[clones[clones.length - 1]][0].outerHTML + prepend;
+      }
+
+      this._clones = clones;
+
+      $(append).addClass('cloned').appendTo(this.$stage);
+      $(prepend).addClass('cloned').prependTo(this.$stage);
+    }
+  }, {
+    filter: [ 'width', 'items', 'settings' ],
+    run: function() {
+      var rtl = this.settings.rtl ? 1 : -1,
+        size = this._clones.length + this._items.length,
+        iterator = -1,
+        previous = 0,
+        current = 0,
+        coordinates = [];
+
+      while (++iterator < size) {
+        previous = coordinates[iterator - 1] || 0;
+        current = this._widths[this.relative(iterator)] + this.settings.margin;
+        coordinates.push(previous + current * rtl);
+      }
+
+      this._coordinates = coordinates;
+    }
+  }, {
+    filter: [ 'width', 'items', 'settings' ],
+    run: function() {
+      var padding = this.settings.stagePadding,
+        coordinates = this._coordinates,
+        css = {
+          'width': Math.ceil(Math.abs(coordinates[coordinates.length - 1])) + padding * 2,
+          'padding-left': padding || '',
+          'padding-right': padding || ''
         };
 
-        $.each(['onResize', 'onThrottledResize'], $.proxy(function (i, handler) {
-            this._handlers[handler] = $.proxy(this[handler], this);
-        }, this));
+      this.$stage.css(css);
+    }
+  }, {
+    filter: [ 'width', 'items', 'settings' ],
+    run: function(cache) {
+      var iterator = this._coordinates.length,
+        grid = !this.settings.autoWidth,
+        items = this.$stage.children();
 
-        $.each(Owl.Plugins, $.proxy(function (key, plugin) {
-            this._plugins[key.charAt(0).toLowerCase() + key.slice(1)]
-              = new plugin(this);
-        }, this));
+      if (grid && cache.items.merge) {
+        while (iterator--) {
+          cache.css.width = this._widths[this.relative(iterator)];
+          items.eq(iterator).css(cache.css);
+        }
+      } else if (grid) {
+        cache.css.width = cache.items.width;
+        items.css(cache.css);
+      }
+    }
+  }, {
+    filter: [ 'items' ],
+    run: function() {
+      this._coordinates.length < 1 && this.$stage.removeAttr('style');
+    }
+  }, {
+    filter: [ 'width', 'items', 'settings' ],
+    run: function(cache) {
+      cache.current = cache.current ? this.$stage.children().index(cache.current) : 0;
+      cache.current = Math.max(this.minimum(), Math.min(this.maximum(), cache.current));
+      this.reset(cache.current);
+    }
+  }, {
+    filter: [ 'position' ],
+    run: function() {
+      this.animate(this.coordinates(this._current));
+    }
+  }, {
+    filter: [ 'width', 'position', 'items', 'settings' ],
+    run: function() {
+      var rtl = this.settings.rtl ? 1 : -1,
+        padding = this.settings.stagePadding * 2,
+        begin = this.coordinates(this.current()) + padding,
+        end = begin + this.width() * rtl,
+        inner, outer, matches = [], i, n;
 
-        $.each(Owl.Workers, $.proxy(function (priority, worker) {
-            this._pipe.push({
-                'filter': worker.filter,
-                'run': $.proxy(worker.run, this)
-            });
-        }, this));
+      for (i = 0, n = this._coordinates.length; i < n; i++) {
+        inner = this._coordinates[i - 1] || 0;
+        outer = Math.abs(this._coordinates[i]) + padding * rtl;
 
-        this.setup();
-        this.initialize();
+        if ((this.op(inner, '<=', begin) && (this.op(inner, '>', end)))
+          || (this.op(outer, '<', begin) && this.op(outer, '>', end))) {
+          matches.push(i);
+        }
+      }
+
+      this.$stage.children('.active').removeClass('active');
+      this.$stage.children(':eq(' + matches.join('), :eq(') + ')').addClass('active');
+
+      if (this.settings.center) {
+        this.$stage.children('.center').removeClass('center');
+        this.$stage.children().eq(this.current()).addClass('center');
+      }
+    }
+  } ];
+
+  /**
+   * Initializes the carousel.
+   * @protected
+   */
+  Owl.prototype.initialize = function() {
+    this.enter('initializing');
+    this.trigger('initialize');
+
+    this.$element.toggleClass(this.settings.rtlClass, this.settings.rtl);
+
+    if (this.settings.autoWidth && !this.is('pre-loading')) {
+      var imgs, nestedSelector, width;
+      imgs = this.$element.find('img');
+      nestedSelector = this.settings.nestedItemSelector ? '.' + this.settings.nestedItemSelector : undefined;
+      width = this.$element.children(nestedSelector).width();
+
+      if (imgs.length && width <= 0) {
+        this.preloadAutoWidthImages(imgs);
+      }
     }
 
-    /**
-     * Default options for the carousel.
-     * @public
-     */
-    Owl.Defaults = {
-        items: 3,
-        autoplay: false,
-        autoplauhoverpause: true,
-        loop: true,
-        center: false,
-        rewind: false,
-
-        mouseDrag: true,
-        touchDrag: true,
-        pullDrag: true,
-        freeDrag: false,
-
-        margin: 0,
-        stagePadding: 0,
-
-        merge: false,
-        mergeFit: true,
-        autoWidth: false,
-
-        startPosition: 0,
-        rtl: false,
-
-        smartSpeed: 250,
-        fluidSpeed: false,
-        dragEndSpeed: false,
-
-        responsive: {},
-        responsiveRefreshRate: 200,
-        responsiveBaseElement: window,
-
-        fallbackEasing: 'swing',
-
-        info: false,
-
-        nestedItemSelector: false,
-        itemElement: 'div',
-        stageElement: 'div',
-
-        refreshClass: 'owl-refresh',
-        loadedClass: 'owl-loaded',
-        loadingClass: 'owl-loading',
-        rtlClass: 'owl-rtl',
-        responsiveClass: 'owl-responsive',
-        dragClass: 'owl-drag',
-        itemClass: 'owl-item',
-        stageClass: 'owl-stage',
-        stageOuterClass: 'owl-stage-outer',
-        grabClass: 'owl-grab'
-    };
-
-    /**
-     * Enumeration for width.
-     * @public
-     * @readonly
-     * @enum {String}
-     */
-    Owl.Width = {
-        Default: 'default',
-        Inner: 'inner',
-        Outer: 'outer'
-    };
-
-    /**
-     * Enumeration for types.
-     * @public
-     * @readonly
-     * @enum {String}
-     */
-    Owl.Type = {
-        Event: 'event',
-        State: 'state'
-    };
-
-    /**
-     * Contains all registered plugins.
-     * @public
-     */
-    Owl.Plugins = {};
-
-    /**
-     * List of workers involved in the update process.
-     */
-    Owl.Workers = [{
-        filter: ['width', 'settings'],
-        run: function () {
-            this._width = this.$element.width();
-        }
-    }, {
-        filter: ['width', 'items', 'settings'],
-        run: function (cache) {
-            cache.current = this._items && this._items[this.relative(this._current)];
-        }
-    }, {
-        filter: ['items', 'settings'],
-        run: function () {
-            this.$stage.children('.cloned').remove();
-        }
-    }, {
-        filter: ['width', 'items', 'settings'],
-        run: function (cache) {
-            var margin = this.settings.margin || '',
-              grid = !this.settings.autoWidth,
-              rtl = this.settings.rtl,
-              css = {
-                  'width': 'auto',
-                  'margin-left': rtl ? margin : '',
-                  'margin-right': rtl ? '' : margin
-              };
-
-            !grid && this.$stage.children().css(css);
-
-            cache.css = css;
-        }
-    }, {
-        filter: ['width', 'items', 'settings'],
-        run: function (cache) {
-            var width = (this.width() / this.settings.items).toFixed(3) - this.settings.margin,
-              merge = null,
-              iterator = this._items.length,
-              grid = !this.settings.autoWidth,
-              widths = [];
-
-            cache.items = {
-                merge: false,
-                width: width
-            };
-
-            while (iterator--) {
-                merge = this._mergers[iterator];
-                merge = this.settings.mergeFit && Math.min(merge, this.settings.items) || merge;
-
-                cache.items.merge = merge > 1 || cache.items.merge;
-
-                widths[iterator] = !grid ? this._items[iterator].width() : width * merge;
-            }
-
-            this._widths = widths;
-        }
-    }, {
-        filter: ['items', 'settings'],
-        run: function () {
-            var clones = [],
-              items = this._items,
-              settings = this.settings,
-              view = Math.max(settings.items * 2, 4),
-              size = Math.ceil(items.length / 2) * 2,
-              repeat = settings.loop && items.length ? settings.rewind ? view : Math.max(view, size) : 0,
-              append = '',
-              prepend = '';
-
-            repeat /= 2;
-
-            while (repeat--) {
-                clones.push(this.normalize(clones.length / 2, true));
-                append = append + items[clones[clones.length - 1]][0].outerHTML;
-                clones.push(this.normalize(items.length - 1 - (clones.length - 1) / 2, true));
-                prepend = items[clones[clones.length - 1]][0].outerHTML + prepend;
-            }
-
-            this._clones = clones;
-
-            $(append).addClass('cloned').appendTo(this.$stage);
-            $(prepend).addClass('cloned').prependTo(this.$stage);
-        }
-    }, {
-        filter: ['width', 'items', 'settings'],
-        run: function () {
-            var rtl = this.settings.rtl ? 1 : -1,
-              size = this._clones.length + this._items.length,
-              iterator = -1,
-              previous = 0,
-              current = 0,
-              coordinates = [];
-
-            while (++iterator < size) {
-                previous = coordinates[iterator - 1] || 0;
-                current = this._widths[this.relative(iterator)] + this.settings.margin;
-                coordinates.push(previous + current * rtl);
-            }
-
-            this._coordinates = coordinates;
-        }
-    }, {
-        filter: ['width', 'items', 'settings'],
-        run: function () {
-            var padding = this.settings.stagePadding,
-              coordinates = this._coordinates,
-              css = {
-                  'width': Math.ceil(Math.abs(coordinates[coordinates.length - 1])) + padding * 2,
-                  'padding-left': padding || '',
-                  'padding-right': padding || ''
-              };
-
-            this.$stage.css(css);
-        }
-    }, {
-        filter: ['width', 'items', 'settings'],
-        run: function (cache) {
-            var iterator = this._coordinates.length,
-              grid = !this.settings.autoWidth,
-              items = this.$stage.children();
-
-            if (grid && cache.items.merge) {
-                while (iterator--) {
-                    cache.css.width = this._widths[this.relative(iterator)];
-                    items.eq(iterator).css(cache.css);
-                }
-            } else if (grid) {
-                cache.css.width = cache.items.width;
-                items.css(cache.css);
-            }
-        }
-    }, {
-        filter: ['items'],
-        run: function () {
-            this._coordinates.length < 1 && this.$stage.removeAttr('style');
-        }
-    }, {
-        filter: ['width', 'items', 'settings'],
-        run: function (cache) {
-            cache.current = cache.current ? this.$stage.children().index(cache.current) : 0;
-            cache.current = Math.max(this.minimum(), Math.min(this.maximum(), cache.current));
-            this.reset(cache.current);
-        }
-    }, {
-        filter: ['position'],
-        run: function () {
-            this.animate(this.coordinates(this._current));
-        }
-    }, {
-        filter: ['width', 'position', 'items', 'settings'],
-        run: function () {
-            var rtl = this.settings.rtl ? 1 : -1,
-              padding = this.settings.stagePadding * 2,
-              begin = this.coordinates(this.current()) + padding,
-              end = begin + this.width() * rtl,
-              inner, outer, matches = [], i, n;
-
-            for (i = 0, n = this._coordinates.length; i < n; i++) {
-                inner = this._coordinates[i - 1] || 0;
-                outer = Math.abs(this._coordinates[i]) + padding * rtl;
-
-                if ((this.op(inner, '<=', begin) && (this.op(inner, '>', end)))
-                  || (this.op(outer, '<', begin) && this.op(outer, '>', end))) {
-                    matches.push(i);
-                }
-            }
-
-            this.$stage.children('.active').removeClass('active');
-            this.$stage.children(':eq(' + matches.join('), :eq(') + ')').addClass('active');
-
-            if (this.settings.center) {
-                this.$stage.children('.center').removeClass('center');
-                this.$stage.children().eq(this.current()).addClass('center');
-            }
-        }
-    }];
-
-    /**
-     * Initializes the carousel.
-     * @protected
-     */
-    Owl.prototype.initialize = function () {
-        this.enter('initializing');
-        this.trigger('initialize');
-
-        this.$element.toggleClass(this.settings.rtlClass, this.settings.rtl);
-
-        if (this.settings.autoWidth && !this.is('pre-loading')) {
-            var imgs, nestedSelector, width;
-            imgs = this.$element.find('img');
-            nestedSelector = this.settings.nestedItemSelector ? '.' + this.settings.nestedItemSelector : undefined;
-            width = this.$element.children(nestedSelector).width();
-
-            if (imgs.length && width <= 0) {
-                this.preloadAutoWidthImages(imgs);
-            }
-        }
-
-        this.$element.addClass(this.options.loadingClass);
-
-        // create stage
-        this.$stage = $('<' + this.settings.stageElement + ' class="' + this.settings.stageClass + '"/>')
-          .wrap('<div class="' + this.settings.stageOuterClass + '"/>');
-
-        // append stage
-        this.$element.append(this.$stage.parent());
-
-        // append content
-        this.replace(this.$element.children().not(this.$stage.parent()));
-
-        // check visibility
-        if (this.$element.is(':visible')) {
-            // update view
-            this.refresh();
-        } else {
-            // invalidate width
-            this.invalidate('width');
-        }
-
-        this.$element
-          .removeClass(this.options.loadingClass)
-          .addClass(this.options.loadedClass);
-
-        // register event handlers
-        this.registerEventHandlers();
-
-        this.leave('initializing');
-        this.trigger('initialized');
-    };
-
-    /**
-     * Setups the current settings.
-     * @todo Remove responsive classes. Why should adaptive designs be brought into IE8?
-     * @todo Support for media queries by using `matchMedia` would be nice.
-     * @public
-     */
-    Owl.prototype.setup = function () {
-        var viewport = this.viewport(),
-          overwrites = this.options.responsive,
-          match = -1,
-          settings = null;
-
-        if (!overwrites) {
-            settings = $.extend({}, this.options);
-        } else {
-            $.each(overwrites, function (breakpoint) {
-                if (breakpoint <= viewport && breakpoint > match) {
-                    match = Number(breakpoint);
-                }
-            });
-
-            settings = $.extend({}, this.options, overwrites[match]);
-            delete settings.responsive;
-
-            // responsive class
-            if (settings.responsiveClass) {
-                this.$element.attr('class',
-                  this.$element.attr('class').replace(new RegExp('(' + this.options.responsiveClass + '-)\\S+\\s', 'g'), '$1' + match)
-                );
-            }
-        }
-
-        if (this.settings === null || this._breakpoint !== match) {
-            this.trigger('change', { property: { name: 'settings', value: settings } });
-            this._breakpoint = match;
-            this.settings = settings;
-            this.invalidate('settings');
-            this.trigger('changed', { property: { name: 'settings', value: this.settings } });
-        }
-    };
-
-    /**
-     * Updates option logic if necessery.
-     * @protected
-     */
-    Owl.prototype.optionsLogic = function () {
-        if (this.settings.autoWidth) {
-            this.settings.stagePadding = false;
-            this.settings.merge = false;
-        }
-    };
-
-    /**
-     * Prepares an item before add.
-     * @todo Rename event parameter `content` to `item`.
-     * @protected
-     * @returns {jQuery|HTMLElement} - The item container.
-     */
-    Owl.prototype.prepare = function (item) {
-        var event = this.trigger('prepare', { content: item });
-
-        if (!event.data) {
-            event.data = $('<' + this.settings.itemElement + '/>')
-              .addClass(this.options.itemClass).append(item)
-        }
-
-        this.trigger('prepared', { content: event.data });
-
-        return event.data;
-    };
-
-    /**
-     * Updates the view.
-     * @public
-     */
-    Owl.prototype.update = function () {
-        var i = 0,
-          n = this._pipe.length,
-          filter = $.proxy(function (p) { return this[p] }, this._invalidated),
-          cache = {};
-
-        while (i < n) {
-            if (this._invalidated.all || $.grep(this._pipe[i].filter, filter).length > 0) {
-                this._pipe[i].run(cache);
-            }
-            i++;
-        }
-
-        this._invalidated = {};
-
-        !this.is('valid') && this.enter('valid');
-    };
-
-    /**
-     * Gets the width of the view.
-     * @public
-     * @param {Owl.Width} [dimension=Owl.Width.Default] - The dimension to return.
-     * @returns {Number} - The width of the view in pixel.
-     */
-    Owl.prototype.width = function (dimension) {
-        dimension = dimension || Owl.Width.Default;
-        switch (dimension) {
-            case Owl.Width.Inner:
-            case Owl.Width.Outer:
-                return this._width;
-            default:
-                return this._width - this.settings.stagePadding * 2 + this.settings.margin;
-        }
-    };
-
-    /**
-     * Refreshes the carousel primarily for adaptive purposes.
-     * @public
-     */
-    Owl.prototype.refresh = function () {
-        this.enter('refreshing');
-        this.trigger('refresh');
-
-        this.setup();
-
-        this.optionsLogic();
-
-        this.$element.addClass(this.options.refreshClass);
-
-        this.update();
-
-        this.$element.removeClass(this.options.refreshClass);
-
-        this.leave('refreshing');
-        this.trigger('refreshed');
-    };
-
-    /**
-     * Checks window `resize` event.
-     * @protected
-     */
-    Owl.prototype.onThrottledResize = function () {
-        window.clearTimeout(this.resizeTimer);
-        this.resizeTimer = window.setTimeout(this._handlers.onResize, this.settings.responsiveRefreshRate);
-    };
-
-    /**
-     * Checks window `resize` event.
-     * @protected
-     */
-    Owl.prototype.onResize = function () {
-        if (!this._items.length) {
-            return false;
-        }
-
-        if (this._width === this.$element.width()) {
-            return false;
-        }
-
-        if (!this.$element.is(':visible')) {
-            return false;
-        }
-
-        this.enter('resizing');
-
-        if (this.trigger('resize').isDefaultPrevented()) {
-            this.leave('resizing');
-            return false;
-        }
-
-        this.invalidate('width');
-
-        this.refresh();
-
-        this.leave('resizing');
-        this.trigger('resized');
-    };
-
-    /**
-     * Registers event handlers.
-     * @todo Check `msPointerEnabled`
-     * @todo #261
-     * @protected
-     */
-    Owl.prototype.registerEventHandlers = function () {
-        if ($.support.transition) {
-            this.$stage.on($.support.transition.end + '.owl.core', $.proxy(this.onTransitionEnd, this));
-        }
-
-        if (this.settings.responsive !== false) {
-            this.on(window, 'resize', this._handlers.onThrottledResize);
-        }
-
-        if (this.settings.mouseDrag) {
-            this.$element.addClass(this.options.dragClass);
-            this.$stage.on('mousedown.owl.core', $.proxy(this.onDragStart, this));
-            this.$stage.on('dragstart.owl.core selectstart.owl.core', function () { return false });
-        }
-
-        if (this.settings.touchDrag) {
-            this.$stage.on('touchstart.owl.core', $.proxy(this.onDragStart, this));
-            this.$stage.on('touchcancel.owl.core', $.proxy(this.onDragEnd, this));
-        }
-    };
-
-    /**
-     * Handles `touchstart` and `mousedown` events.
-     * @todo Horizontal swipe threshold as option
-     * @todo #261
-     * @protected
-     * @param {Event} event - The event arguments.
-     */
-    Owl.prototype.onDragStart = function (event) {
-        var stage = null;
-
-        if (event.which === 3) {
-            return;
-        }
-
-        if ($.support.transform) {
-            stage = this.$stage.css('transform').replace(/.*\(|\)| /g, '').split(',');
-            stage = {
-                x: stage[stage.length === 16 ? 12 : 4],
-                y: stage[stage.length === 16 ? 13 : 5]
-            };
-        } else {
-            stage = this.$stage.position();
-            stage = {
-                x: this.settings.rtl ?
-                  stage.left + this.$stage.width() - this.width() + this.settings.margin :
-                  stage.left,
-                y: stage.top
-            };
-        }
-
-        if (this.is('animating')) {
-            $.support.transform ? this.animate(stage.x) : this.$stage.stop()
-            this.invalidate('position');
-        }
-
-        this.$element.toggleClass(this.options.grabClass, event.type === 'mousedown');
-
-        this.speed(0);
-
-        this._drag.time = new Date().getTime();
-        this._drag.target = $(event.target);
-        this._drag.stage.start = stage;
-        this._drag.stage.current = stage;
-        this._drag.pointer = this.pointer(event);
-
-        $(document).on('mouseup.owl.core touchend.owl.core', $.proxy(this.onDragEnd, this));
-
-        $(document).one('mousemove.owl.core touchmove.owl.core', $.proxy(function (event) {
-            var delta = this.difference(this._drag.pointer, this.pointer(event));
-
-            $(document).on('mousemove.owl.core touchmove.owl.core', $.proxy(this.onDragMove, this));
-
-            if (Math.abs(delta.x) < Math.abs(delta.y) && this.is('valid')) {
-                return;
-            }
-
-            event.preventDefault();
-
-            this.enter('dragging');
-            this.trigger('drag');
-        }, this));
-    };
-
-    /**
-     * Handles the `touchmove` and `mousemove` events.
-     * @todo #261
-     * @protected
-     * @param {Event} event - The event arguments.
-     */
-    Owl.prototype.onDragMove = function (event) {
-        var minimum = null,
-          maximum = null,
-          pull = null,
-          delta = this.difference(this._drag.pointer, this.pointer(event)),
-          stage = this.difference(this._drag.stage.start, delta);
-
-        if (!this.is('dragging')) {
-            return;
-        }
-
-        event.preventDefault();
-
-        if (this.settings.loop) {
-            minimum = this.coordinates(this.minimum());
-            maximum = this.coordinates(this.maximum() + 1) - minimum;
-            stage.x = (((stage.x - minimum) % maximum + maximum) % maximum) + minimum;
-        } else {
-            minimum = this.settings.rtl ? this.coordinates(this.maximum()) : this.coordinates(this.minimum());
-            maximum = this.settings.rtl ? this.coordinates(this.minimum()) : this.coordinates(this.maximum());
-            pull = this.settings.pullDrag ? -1 * delta.x / 5 : 0;
-            stage.x = Math.max(Math.min(stage.x, minimum + pull), maximum + pull);
-        }
-
-        this._drag.stage.current = stage;
-
-        this.animate(stage.x);
-    };
-
-    /**
-     * Handles the `touchend` and `mouseup` events.
-     * @todo #261
-     * @todo Threshold for click event
-     * @protected
-     * @param {Event} event - The event arguments.
-     */
-    Owl.prototype.onDragEnd = function (event) {
-        var delta = this.difference(this._drag.pointer, this.pointer(event)),
-          stage = this._drag.stage.current,
-          direction = delta.x > 0 ^ this.settings.rtl ? 'left' : 'right';
-
-        $(document).off('.owl.core');
-
-        this.$element.removeClass(this.options.grabClass);
-
-        if (delta.x !== 0 && this.is('dragging') || !this.is('valid')) {
-            this.speed(this.settings.dragEndSpeed || this.settings.smartSpeed);
-            this.current(this.closest(stage.x, delta.x !== 0 ? direction : this._drag.direction));
-            this.invalidate('position');
-            this.update();
-
-            this._drag.direction = direction;
-
-            if (Math.abs(delta.x) > 3 || new Date().getTime() - this._drag.time > 300) {
-                this._drag.target.one('click.owl.core', function () { return false; });
-            }
-        }
-
-        if (!this.is('dragging')) {
-            return;
-        }
-
-        this.leave('dragging');
-        this.trigger('dragged');
-    };
-
-    /**
-     * Gets absolute position of the closest item for a coordinate.
-     * @todo Setting `freeDrag` makes `closest` not reusable. See #165.
-     * @protected
-     * @param {Number} coordinate - The coordinate in pixel.
-     * @param {String} direction - The direction to check for the closest item. Ether `left` or `right`.
-     * @return {Number} - The absolute position of the closest item.
-     */
-    Owl.prototype.closest = function (coordinate, direction) {
-        var position = -1,
-          pull = 30,
-          width = this.width(),
-          coordinates = this.coordinates();
-
-        if (!this.settings.freeDrag) {
-            // check closest item
-            $.each(coordinates, $.proxy(function (index, value) {
-                if (coordinate > value - pull && coordinate < value + pull) {
-                    position = index;
-                } else if (this.op(coordinate, '<', value)
-                  && this.op(coordinate, '>', coordinates[index + 1] || value - width)) {
-                    position = direction === 'left' ? index + 1 : index;
-                }
-                return position === -1;
-            }, this));
-        }
-
-        if (!this.settings.loop) {
-            // non loop boundries
-            if (this.op(coordinate, '>', coordinates[this.minimum()])) {
-                position = coordinate = this.minimum();
-            } else if (this.op(coordinate, '<', coordinates[this.maximum()])) {
-                position = coordinate = this.maximum();
-            }
-        }
-
-        return position;
-    };
-
-    /**
-     * Animates the stage.
-     * @todo #270
-     * @public
-     * @param {Number} coordinate - The coordinate in pixels.
-     */
-    Owl.prototype.animate = function (coordinate) {
-        var animate = this.speed() > 0;
-
-        this.is('animating') && this.onTransitionEnd();
-
-        if (animate) {
-            this.enter('animating');
-            this.trigger('translate');
-        }
-
-        if ($.support.transform3d && $.support.transition) {
-            this.$stage.css({
-                transform: 'translate3d(' + coordinate + 'px,0px,0px)',
-                transition: (this.speed() / 1000) + 's'
-            });
-        } else if (animate) {
-            this.$stage.animate({
-                left: coordinate + 'px'
-            }, this.speed(), this.settings.fallbackEasing, $.proxy(this.onTransitionEnd, this));
-        } else {
-            this.$stage.css({
-                left: coordinate + 'px'
-            });
-        }
-    };
-
-    /**
-     * Checks whether the carousel is in a specific state or not.
-     * @param {String} state - The state to check.
-     * @returns {Boolean} - The flag which indicates if the carousel is busy.
-     */
-    Owl.prototype.is = function (state) {
-        return this._states.current[state] && this._states.current[state] > 0;
-    };
-
-    /**
-     * Sets the absolute position of the current item.
-     * @public
-     * @param {Number} [position] - The new absolute position or nothing to leave it unchanged.
-     * @returns {Number} - The absolute position of the current item.
-     */
-    Owl.prototype.current = function (position) {
-        if (position === undefined) {
-            return this._current;
-        }
-
-        if (this._items.length === 0) {
-            return undefined;
-        }
-
-        position = this.normalize(position);
-
-        if (this._current !== position) {
-            var event = this.trigger('change', { property: { name: 'position', value: position } });
-
-            if (event.data !== undefined) {
-                position = this.normalize(event.data);
-            }
-
-            this._current = position;
-
-            this.invalidate('position');
-
-            this.trigger('changed', { property: { name: 'position', value: this._current } });
-        }
-
-        return this._current;
-    };
-
-    /**
-     * Invalidates the given part of the update routine.
-     * @param {String} [part] - The part to invalidate.
-     * @returns {Array.<String>} - The invalidated parts.
-     */
-    Owl.prototype.invalidate = function (part) {
-        if ($.type(part) === 'string') {
-            this._invalidated[part] = true;
-            this.is('valid') && this.leave('valid');
-        }
-        return $.map(this._invalidated, function (v, i) { return i });
-    };
-
-    /**
-     * Resets the absolute position of the current item.
-     * @public
-     * @param {Number} position - The absolute position of the new item.
-     */
-    Owl.prototype.reset = function (position) {
-        position = this.normalize(position);
-
-        if (position === undefined) {
-            return;
-        }
-
-        this._speed = 0;
-        this._current = position;
-
-        this.suppress(['translate', 'translated']);
-
-        this.animate(this.coordinates(position));
-
-        this.release(['translate', 'translated']);
-    };
-
-    /**
-     * Normalizes an absolute or a relative position of an item.
-     * @public
-     * @param {Number} position - The absolute or relative position to normalize.
-     * @param {Boolean} [relative=false] - Whether the given position is relative or not.
-     * @returns {Number} - The normalized position.
-     */
-    Owl.prototype.normalize = function (position, relative) {
-        var n = this._items.length,
-          m = relative ? 0 : this._clones.length;
-
-        if (!$.isNumeric(position) || n < 1) {
-            position = undefined;
-        } else if (position < 0 || position >= n + m) {
-            position = ((position - m / 2) % n + n) % n + m / 2;
-        }
-
-        return position;
-    };
-
-    /**
-     * Converts an absolute position of an item into a relative one.
-     * @public
-     * @param {Number} position - The absolute position to convert.
-     * @returns {Number} - The converted position.
-     */
-    Owl.prototype.relative = function (position) {
-        position -= this._clones.length / 2;
-        return this.normalize(position, true);
-    };
-
-    /**
-     * Gets the maximum position for the current item.
-     * @public
-     * @param {Boolean} [relative=false] - Whether to return an absolute position or a relative position.
-     * @returns {Number}
-     */
-    Owl.prototype.maximum = function (relative) {
-        var settings = this.settings,
-          maximum = this._coordinates.length,
-          boundary = Math.abs(this._coordinates[maximum - 1]) - this._width,
-          i = -1, j;
-
-        if (settings.loop) {
-            maximum = this._clones.length / 2 + this._items.length - 1;
-        } else if (settings.autoWidth || settings.merge) {
-            // binary search
-            while (maximum - i > 1) {
-                Math.abs(this._coordinates[j = maximum + i >> 1]) < boundary
-                  ? i = j : maximum = j;
-            }
-        } else if (settings.center) {
-            maximum = this._items.length - 1;
-        } else {
-            maximum = this._items.length - settings.items;
-        }
-
-        if (relative) {
-            maximum -= this._clones.length / 2;
-        }
-
-        return Math.max(maximum, 0);
-    };
-
-    /**
-     * Gets the minimum position for the current item.
-     * @public
-     * @param {Boolean} [relative=false] - Whether to return an absolute position or a relative position.
-     * @returns {Number}
-     */
-    Owl.prototype.minimum = function (relative) {
-        return relative ? 0 : this._clones.length / 2;
-    };
-
-    /**
-     * Gets an item at the specified relative position.
-     * @public
-     * @param {Number} [position] - The relative position of the item.
-     * @return {jQuery|Array.<jQuery>} - The item at the given position or all items if no position was given.
-     */
-    Owl.prototype.items = function (position) {
-        if (position === undefined) {
-            return this._items.slice();
-        }
-
-        position = this.normalize(position, true);
-        return this._items[position];
-    };
-
-    /**
-     * Gets an item at the specified relative position.
-     * @public
-     * @param {Number} [position] - The relative position of the item.
-     * @return {jQuery|Array.<jQuery>} - The item at the given position or all items if no position was given.
-     */
-    Owl.prototype.mergers = function (position) {
-        if (position === undefined) {
-            return this._mergers.slice();
-        }
-
-        position = this.normalize(position, true);
-        return this._mergers[position];
-    };
-
-    /**
-     * Gets the absolute positions of clones for an item.
-     * @public
-     * @param {Number} [position] - The relative position of the item.
-     * @returns {Array.<Number>} - The absolute positions of clones for the item or all if no position was given.
-     */
-    Owl.prototype.clones = function (position) {
-        var odd = this._clones.length / 2,
-          even = odd + this._items.length,
-          map = function (index) { return index % 2 === 0 ? even + index / 2 : odd - (index + 1) / 2 };
-
-        if (position === undefined) {
-            return $.map(this._clones, function (v, i) { return map(i) });
-        }
-
-        return $.map(this._clones, function (v, i) { return v === position ? map(i) : null });
-    };
-
-    /**
-     * Sets the current animation speed.
-     * @public
-     * @param {Number} [speed] - The animation speed in milliseconds or nothing to leave it unchanged.
-     * @returns {Number} - The current animation speed in milliseconds.
-     */
-    Owl.prototype.speed = function (speed) {
-        if (speed !== undefined) {
-            this._speed = speed;
-        }
-
-        return this._speed;
-    };
-
-    /**
-     * Gets the coordinate of an item.
-     * @todo The name of this method is missleanding.
-     * @public
-     * @param {Number} position - The absolute position of the item within `minimum()` and `maximum()`.
-     * @returns {Number|Array.<Number>} - The coordinate of the item in pixel or all coordinates.
-     */
-    Owl.prototype.coordinates = function (position) {
-        var coordinate = null;
-
-        if (position === undefined) {
-            return $.map(this._coordinates, $.proxy(function (coordinate, index) {
-                return this.coordinates(index);
-            }, this));
-        }
-
-        if (this.settings.center) {
-            coordinate = this._coordinates[position];
-            coordinate += (this.width() - coordinate + (this._coordinates[position - 1] || 0)) / 2 * (this.settings.rtl ? -1 : 1);
-        } else {
-            coordinate = this._coordinates[position - 1] || 0;
-        }
-
-        return coordinate;
-    };
-
-    /**
-     * Calculates the speed for a translation.
-     * @protected
-     * @param {Number} from - The absolute position of the start item.
-     * @param {Number} to - The absolute position of the target item.
-     * @param {Number} [factor=undefined] - The time factor in milliseconds.
-     * @returns {Number} - The time in milliseconds for the translation.
-     */
-    Owl.prototype.duration = function (from, to, factor) {
-        return Math.min(Math.max(Math.abs(to - from), 1), 6) * Math.abs((factor || this.settings.smartSpeed));
-    };
-
-    /**
-     * Slides to the specified item.
-     * @public
-     * @param {Number} position - The position of the item.
-     * @param {Number} [speed] - The time in milliseconds for the transition.
-     */
-    Owl.prototype.to = function (position, speed) {
-        var current = this.current(),
-          revert = null,
-          distance = position - this.relative(current),
-          direction = (distance > 0) - (distance < 0),
-          items = this._items.length,
-          minimum = this.minimum(),
-          maximum = this.maximum();
-
-        if (this.settings.loop) {
-            if (!this.settings.rewind && Math.abs(distance) > items / 2) {
-                distance += direction * -1 * items;
-            }
-
-            position = current + distance;
-            revert = ((position - minimum) % items + items) % items + minimum;
-
-            if (revert !== position && revert - distance <= maximum && revert - distance > 0) {
-                current = revert - distance;
-                position = revert;
-                this.reset(current);
-            }
-        } else if (this.settings.rewind) {
-            maximum += 1;
-            position = (position % maximum + maximum) % maximum;
-        } else {
-            position = Math.max(minimum, Math.min(maximum, position));
-        }
-
-        this.speed(this.duration(current, position, speed));
-        this.current(position);
-
-        if (this.$element.is(':visible')) {
-            this.update();
-        }
-    };
-
-    /**
-     * Slides to the next item.
-     * @public
-     * @param {Number} [speed] - The time in milliseconds for the transition.
-     */
-    Owl.prototype.next = function (speed) {
-        speed = speed || false;
-        this.to(this.relative(this.current()) + 1, speed);
-    };
-
-    /**
-     * Slides to the previous item.
-     * @public
-     * @param {Number} [speed] - The time in milliseconds for the transition.
-     */
-    Owl.prototype.prev = function (speed) {
-        speed = speed || false;
-        this.to(this.relative(this.current()) - 1, speed);
-    };
-
-    /**
-     * Handles the end of an animation.
-     * @protected
-     * @param {Event} event - The event arguments.
-     */
-    Owl.prototype.onTransitionEnd = function (event) {
-
-        // if css2 animation then event object is undefined
-        if (event !== undefined) {
-            event.stopPropagation();
-
-            // Catch only owl-stage transitionEnd event
-            if ((event.target || event.srcElement || event.originalTarget) !== this.$stage.get(0)) {
-                return false;
-            }
-        }
-
-        this.leave('animating');
-        this.trigger('translated');
-    };
-
-    /**
-     * Gets viewport width.
-     * @protected
-     * @return {Number} - The width in pixel.
-     */
-    Owl.prototype.viewport = function () {
-        var width;
-        if (this.options.responsiveBaseElement !== window) {
-            width = $(this.options.responsiveBaseElement).width();
-        } else if (window.innerWidth) {
-            width = window.innerWidth;
-        } else if (document.documentElement && document.documentElement.clientWidth) {
-            width = document.documentElement.clientWidth;
-        } else {
-            throw 'Can not detect viewport width.';
-        }
-        return width;
-    };
-
-    /**
-     * Replaces the current content.
-     * @public
-     * @param {HTMLElement|jQuery|String} content - The new content.
-     */
-    Owl.prototype.replace = function (content) {
-        this.$stage.empty();
-        this._items = [];
-
-        if (content) {
-            content = (content instanceof jQuery) ? content : $(content);
-        }
-
-        if (this.settings.nestedItemSelector) {
-            content = content.find('.' + this.settings.nestedItemSelector);
-        }
-
-        content.filter(function () {
-            return this.nodeType === 1;
-        }).each($.proxy(function (index, item) {
-            item = this.prepare(item);
-            this.$stage.append(item);
-            this._items.push(item);
-            this._mergers.push(item.find('[data-merge]').andSelf('[data-merge]').attr('data-merge') * 1 || 1);
-        }, this));
-
-        this.reset($.isNumeric(this.settings.startPosition) ? this.settings.startPosition : 0);
-
-        this.invalidate('items');
-    };
-
-    /**
-     * Adds an item.
-     * @todo Use `item` instead of `content` for the event arguments.
-     * @public
-     * @param {HTMLElement|jQuery|String} content - The item content to add.
-     * @param {Number} [position] - The relative position at which to insert the item otherwise the item will be added to the end.
-     */
-    Owl.prototype.add = function (content, position) {
-        var current = this.relative(this._current);
-
-        position = position === undefined ? this._items.length : this.normalize(position, true);
-        content = content instanceof jQuery ? content : $(content);
-
-        this.trigger('add', { content: content, position: position });
-
-        content = this.prepare(content);
-
-        if (this._items.length === 0 || position === this._items.length) {
-            this._items.length === 0 && this.$stage.append(content);
-            this._items.length !== 0 && this._items[position - 1].after(content);
-            this._items.push(content);
-            this._mergers.push(content.find('[data-merge]').andSelf('[data-merge]').attr('data-merge') * 1 || 1);
-        } else {
-            this._items[position].before(content);
-            this._items.splice(position, 0, content);
-            this._mergers.splice(position, 0, content.find('[data-merge]').andSelf('[data-merge]').attr('data-merge') * 1 || 1);
-        }
-
-        this._items[current] && this.reset(this._items[current].index());
-
-        this.invalidate('items');
-
-        this.trigger('added', { content: content, position: position });
-    };
-
-    /**
-     * Removes an item by its position.
-     * @todo Use `item` instead of `content` for the event arguments.
-     * @public
-     * @param {Number} position - The relative position of the item to remove.
-     */
-    Owl.prototype.remove = function (position) {
-        position = this.normalize(position, true);
-
-        if (position === undefined) {
-            return;
-        }
-
-        this.trigger('remove', { content: this._items[position], position: position });
-
-        this._items[position].remove();
-        this._items.splice(position, 1);
-        this._mergers.splice(position, 1);
-
-        this.invalidate('items');
-
-        this.trigger('removed', { content: null, position: position });
-    };
-
-    /**
-     * Preloads images with auto width.
-     * @todo Replace by a more generic approach
-     * @protected
-     */
-    Owl.prototype.preloadAutoWidthImages = function (images) {
-        images.each($.proxy(function (i, element) {
-            this.enter('pre-loading');
-            element = $(element);
-            $(new Image()).one('load', $.proxy(function (e) {
-                element.attr('src', e.target.src);
-                element.css('opacity', 1);
-                this.leave('pre-loading');
-                !this.is('pre-loading') && !this.is('initializing') && this.refresh();
-            }, this)).attr('src', element.attr('src') || element.attr('data-src') || element.attr('data-src-retina'));
-        }, this));
-    };
-
-    /**
-     * Destroys the carousel.
-     * @public
-     */
-    Owl.prototype.destroy = function () {
-
-        this.$element.off('.owl.core');
-        this.$stage.off('.owl.core');
-        $(document).off('.owl.core');
-
-        if (this.settings.responsive !== false) {
-            window.clearTimeout(this.resizeTimer);
-            this.off(window, 'resize', this._handlers.onThrottledResize);
-        }
-
-        for (var i in this._plugins) {
-            this._plugins[i].destroy();
-        }
-
-        this.$stage.children('.cloned').remove();
-
-        this.$stage.unwrap();
-        this.$stage.children().contents().unwrap();
-        this.$stage.children().unwrap();
-
-        this.$element
-          .removeClass(this.options.refreshClass)
-          .removeClass(this.options.loadingClass)
-          .removeClass(this.options.loadedClass)
-          .removeClass(this.options.rtlClass)
-          .removeClass(this.options.dragClass)
-          .removeClass(this.options.grabClass)
-          .attr('class', this.$element.attr('class').replace(new RegExp(this.options.responsiveClass + '-\\S+\\s', 'g'), ''))
-          .removeData('owl.carousel');
-    };
-
-    /**
-     * Operators to calculate right-to-left and left-to-right.
-     * @protected
-     * @param {Number} [a] - The left side operand.
-     * @param {String} [o] - The operator.
-     * @param {Number} [b] - The right side operand.
-     */
-    Owl.prototype.op = function (a, o, b) {
-        var rtl = this.settings.rtl;
-        switch (o) {
-            case '<':
-                return rtl ? a > b : a < b;
-            case '>':
-                return rtl ? a < b : a > b;
-            case '>=':
-                return rtl ? a <= b : a >= b;
-            case '<=':
-                return rtl ? a >= b : a <= b;
-            default:
-                break;
-        }
-    };
-
-    /**
-     * Attaches to an internal event.
-     * @protected
-     * @param {HTMLElement} element - The event source.
-     * @param {String} event - The event name.
-     * @param {Function} listener - The event handler to attach.
-     * @param {Boolean} capture - Wether the event should be handled at the capturing phase or not.
-     */
-    Owl.prototype.on = function (element, event, listener, capture) {
-        if (element.addEventListener) {
-            element.addEventListener(event, listener, capture);
-        } else if (element.attachEvent) {
-            element.attachEvent('on' + event, listener);
-        }
-    };
-
-    /**
-     * Detaches from an internal event.
-     * @protected
-     * @param {HTMLElement} element - The event source.
-     * @param {String} event - The event name.
-     * @param {Function} listener - The attached event handler to detach.
-     * @param {Boolean} capture - Wether the attached event handler was registered as a capturing listener or not.
-     */
-    Owl.prototype.off = function (element, event, listener, capture) {
-        if (element.removeEventListener) {
-            element.removeEventListener(event, listener, capture);
-        } else if (element.detachEvent) {
-            element.detachEvent('on' + event, listener);
-        }
-    };
-
-    /**
-     * Triggers a public event.
-     * @todo Remove `status`, `relatedTarget` should be used instead.
-     * @protected
-     * @param {String} name - The event name.
-     * @param {*} [data=null] - The event data.
-     * @param {String} [namespace=carousel] - The event namespace.
-     * @param {String} [state] - The state which is associated with the event.
-     * @param {Boolean} [enter=false] - Indicates if the call enters the specified state or not.
-     * @returns {Event} - The event arguments.
-     */
-    Owl.prototype.trigger = function (name, data, namespace, state, enter) {
-        var status = {
-            item: { count: this._items.length, index: this.current() }
-        }, handler = $.camelCase(
-          $.grep(['on', name, namespace], function (v) { return v })
-            .join('-').toLowerCase()
-        ), event = $.Event(
-          [name, 'owl', namespace || 'carousel'].join('.').toLowerCase(),
-          $.extend({ relatedTarget: this }, status, data)
+    this.$element.addClass(this.options.loadingClass);
+
+    // create stage
+    this.$stage = $('<' + this.settings.stageElement + ' class="' + this.settings.stageClass + '"/>')
+      .wrap('<div class="' + this.settings.stageOuterClass + '"/>');
+
+    // append stage
+    this.$element.append(this.$stage.parent());
+
+    // append content
+    this.replace(this.$element.children().not(this.$stage.parent()));
+
+    // check visibility
+    if (this.$element.is(':visible')) {
+      // update view
+      this.refresh();
+    } else {
+      // invalidate width
+      this.invalidate('width');
+    }
+
+    this.$element
+      .removeClass(this.options.loadingClass)
+      .addClass(this.options.loadedClass);
+
+    // register event handlers
+    this.registerEventHandlers();
+
+    this.leave('initializing');
+    this.trigger('initialized');
+  };
+
+  /**
+   * Setups the current settings.
+   * @todo Remove responsive classes. Why should adaptive designs be brought into IE8?
+   * @todo Support for media queries by using `matchMedia` would be nice.
+   * @public
+   */
+  Owl.prototype.setup = function() {
+    var viewport = this.viewport(),
+      overwrites = this.options.responsive,
+      match = -1,
+      settings = null;
+
+    if (!overwrites) {
+      settings = $.extend({}, this.options);
+    } else {
+      $.each(overwrites, function(breakpoint) {
+        if (breakpoint <= viewport && breakpoint > match) {
+          match = Number(breakpoint);
+        }
+      });
+
+      settings = $.extend({}, this.options, overwrites[match]);
+      delete settings.responsive;
+
+      // responsive class
+      if (settings.responsiveClass) {
+        this.$element.attr('class',
+          this.$element.attr('class').replace(new RegExp('(' + this.options.responsiveClass + '-)\\S+\\s', 'g'), '$1' + match)
         );
+      }
+    }
 
-        if (!this._supress[name]) {
-            $.each(this._plugins, function (name, plugin) {
-                if (plugin.onTrigger) {
-                    plugin.onTrigger(event);
-                }
-            });
+    if (this.settings === null || this._breakpoint !== match) {
+      this.trigger('change', { property: { name: 'settings', value: settings } });
+      this._breakpoint = match;
+      this.settings = settings;
+      this.invalidate('settings');
+      this.trigger('changed', { property: { name: 'settings', value: this.settings } });
+    }
+  };
 
-            this.register({ type: Owl.Type.Event, name: name });
-            this.$element.trigger(event);
+  /**
+   * Updates option logic if necessery.
+   * @protected
+   */
+  Owl.prototype.optionsLogic = function() {
+    if (this.settings.autoWidth) {
+      this.settings.stagePadding = false;
+      this.settings.merge = false;
+    }
+  };
 
-            if (this.settings && typeof this.settings[handler] === 'function') {
-                this.settings[handler].call(this, event);
-            }
+  /**
+   * Prepares an item before add.
+   * @todo Rename event parameter `content` to `item`.
+   * @protected
+   * @returns {jQuery|HTMLElement} - The item container.
+   */
+  Owl.prototype.prepare = function(item) {
+    var event = this.trigger('prepare', { content: item });
+
+    if (!event.data) {
+      event.data = $('<' + this.settings.itemElement + '/>')
+        .addClass(this.options.itemClass).append(item)
+    }
+
+    this.trigger('prepared', { content: event.data });
+
+    return event.data;
+  };
+
+  /**
+   * Updates the view.
+   * @public
+   */
+  Owl.prototype.update = function() {
+    var i = 0,
+      n = this._pipe.length,
+      filter = $.proxy(function(p) { return this[p] }, this._invalidated),
+      cache = {};
+
+    while (i < n) {
+      if (this._invalidated.all || $.grep(this._pipe[i].filter, filter).length > 0) {
+        this._pipe[i].run(cache);
+      }
+      i++;
+    }
+
+    this._invalidated = {};
+
+    !this.is('valid') && this.enter('valid');
+  };
+
+  /**
+   * Gets the width of the view.
+   * @public
+   * @param {Owl.Width} [dimension=Owl.Width.Default] - The dimension to return.
+   * @returns {Number} - The width of the view in pixel.
+   */
+  Owl.prototype.width = function(dimension) {
+    dimension = dimension || Owl.Width.Default;
+    switch (dimension) {
+      case Owl.Width.Inner:
+      case Owl.Width.Outer:
+        return this._width;
+      default:
+        return this._width - this.settings.stagePadding * 2 + this.settings.margin;
+    }
+  };
+
+  /**
+   * Refreshes the carousel primarily for adaptive purposes.
+   * @public
+   */
+  Owl.prototype.refresh = function() {
+    this.enter('refreshing');
+    this.trigger('refresh');
+
+    this.setup();
+
+    this.optionsLogic();
+
+    this.$element.addClass(this.options.refreshClass);
+
+    this.update();
+
+    this.$element.removeClass(this.options.refreshClass);
+
+    this.leave('refreshing');
+    this.trigger('refreshed');
+  };
+
+  /**
+   * Checks window `resize` event.
+   * @protected
+   */
+  Owl.prototype.onThrottledResize = function() {
+    window.clearTimeout(this.resizeTimer);
+    this.resizeTimer = window.setTimeout(this._handlers.onResize, this.settings.responsiveRefreshRate);
+  };
+
+  /**
+   * Checks window `resize` event.
+   * @protected
+   */
+  Owl.prototype.onResize = function() {
+    if (!this._items.length) {
+      return false;
+    }
+
+    if (this._width === this.$element.width()) {
+      return false;
+    }
+
+    if (!this.$element.is(':visible')) {
+      return false;
+    }
+
+    this.enter('resizing');
+
+    if (this.trigger('resize').isDefaultPrevented()) {
+      this.leave('resizing');
+      return false;
+    }
+
+    this.invalidate('width');
+
+    this.refresh();
+
+    this.leave('resizing');
+    this.trigger('resized');
+  };
+
+  /**
+   * Registers event handlers.
+   * @todo Check `msPointerEnabled`
+   * @todo #261
+   * @protected
+   */
+  Owl.prototype.registerEventHandlers = function() {
+    if ($.support.transition) {
+      this.$stage.on($.support.transition.end + '.owl.core', $.proxy(this.onTransitionEnd, this));
+    }
+
+    if (this.settings.responsive !== false) {
+      this.on(window, 'resize', this._handlers.onThrottledResize);
+    }
+
+    if (this.settings.mouseDrag) {
+      this.$element.addClass(this.options.dragClass);
+      this.$stage.on('mousedown.owl.core', $.proxy(this.onDragStart, this));
+      this.$stage.on('dragstart.owl.core selectstart.owl.core', function() { return false });
+    }
+
+    if (this.settings.touchDrag){
+      this.$stage.on('touchstart.owl.core', $.proxy(this.onDragStart, this));
+      this.$stage.on('touchcancel.owl.core', $.proxy(this.onDragEnd, this));
+    }
+  };
+
+  /**
+   * Handles `touchstart` and `mousedown` events.
+   * @todo Horizontal swipe threshold as option
+   * @todo #261
+   * @protected
+   * @param {Event} event - The event arguments.
+   */
+  Owl.prototype.onDragStart = function(event) {
+    var stage = null;
+
+    if (event.which === 3) {
+      return;
+    }
+
+    if ($.support.transform) {
+      stage = this.$stage.css('transform').replace(/.*\(|\)| /g, '').split(',');
+      stage = {
+        x: stage[stage.length === 16 ? 12 : 4],
+        y: stage[stage.length === 16 ? 13 : 5]
+      };
+    } else {
+      stage = this.$stage.position();
+      stage = {
+        x: this.settings.rtl ?
+          stage.left + this.$stage.width() - this.width() + this.settings.margin :
+          stage.left,
+        y: stage.top
+      };
+    }
+
+    if (this.is('animating')) {
+      $.support.transform ? this.animate(stage.x) : this.$stage.stop()
+      this.invalidate('position');
+    }
+
+    this.$element.toggleClass(this.options.grabClass, event.type === 'mousedown');
+
+    this.speed(0);
+
+    this._drag.time = new Date().getTime();
+    this._drag.target = $(event.target);
+    this._drag.stage.start = stage;
+    this._drag.stage.current = stage;
+    this._drag.pointer = this.pointer(event);
+
+    $(document).on('mouseup.owl.core touchend.owl.core', $.proxy(this.onDragEnd, this));
+
+    $(document).one('mousemove.owl.core touchmove.owl.core', $.proxy(function(event) {
+      var delta = this.difference(this._drag.pointer, this.pointer(event));
+
+      $(document).on('mousemove.owl.core touchmove.owl.core', $.proxy(this.onDragMove, this));
+
+      if (Math.abs(delta.x) < Math.abs(delta.y) && this.is('valid')) {
+        return;
+      }
+
+      event.preventDefault();
+
+      this.enter('dragging');
+      this.trigger('drag');
+    }, this));
+  };
+
+  /**
+   * Handles the `touchmove` and `mousemove` events.
+   * @todo #261
+   * @protected
+   * @param {Event} event - The event arguments.
+   */
+  Owl.prototype.onDragMove = function(event) {
+    var minimum = null,
+      maximum = null,
+      pull = null,
+      delta = this.difference(this._drag.pointer, this.pointer(event)),
+      stage = this.difference(this._drag.stage.start, delta);
+
+    if (!this.is('dragging')) {
+      return;
+    }
+
+    event.preventDefault();
+
+    if (this.settings.loop) {
+      minimum = this.coordinates(this.minimum());
+      maximum = this.coordinates(this.maximum() + 1) - minimum;
+      stage.x = (((stage.x - minimum) % maximum + maximum) % maximum) + minimum;
+    } else {
+      minimum = this.settings.rtl ? this.coordinates(this.maximum()) : this.coordinates(this.minimum());
+      maximum = this.settings.rtl ? this.coordinates(this.minimum()) : this.coordinates(this.maximum());
+      pull = this.settings.pullDrag ? -1 * delta.x / 5 : 0;
+      stage.x = Math.max(Math.min(stage.x, minimum + pull), maximum + pull);
+    }
+
+    this._drag.stage.current = stage;
+
+    this.animate(stage.x);
+  };
+
+  /**
+   * Handles the `touchend` and `mouseup` events.
+   * @todo #261
+   * @todo Threshold for click event
+   * @protected
+   * @param {Event} event - The event arguments.
+   */
+  Owl.prototype.onDragEnd = function(event) {
+    var delta = this.difference(this._drag.pointer, this.pointer(event)),
+      stage = this._drag.stage.current,
+      direction = delta.x > 0 ^ this.settings.rtl ? 'left' : 'right';
+
+    $(document).off('.owl.core');
+
+    this.$element.removeClass(this.options.grabClass);
+
+    if (delta.x !== 0 && this.is('dragging') || !this.is('valid')) {
+      this.speed(this.settings.dragEndSpeed || this.settings.smartSpeed);
+      this.current(this.closest(stage.x, delta.x !== 0 ? direction : this._drag.direction));
+      this.invalidate('position');
+      this.update();
+
+      this._drag.direction = direction;
+
+      if (Math.abs(delta.x) > 3 || new Date().getTime() - this._drag.time > 300) {
+        this._drag.target.one('click.owl.core', function() { return false; });
+      }
+    }
+
+    if (!this.is('dragging')) {
+      return;
+    }
+
+    this.leave('dragging');
+    this.trigger('dragged');
+  };
+
+  /**
+   * Gets absolute position of the closest item for a coordinate.
+   * @todo Setting `freeDrag` makes `closest` not reusable. See #165.
+   * @protected
+   * @param {Number} coordinate - The coordinate in pixel.
+   * @param {String} direction - The direction to check for the closest item. Ether `left` or `right`.
+   * @return {Number} - The absolute position of the closest item.
+   */
+  Owl.prototype.closest = function(coordinate, direction) {
+    var position = -1,
+      pull = 30,
+      width = this.width(),
+      coordinates = this.coordinates();
+
+    if (!this.settings.freeDrag) {
+      // check closest item
+      $.each(coordinates, $.proxy(function(index, value) {
+        if (coordinate > value - pull && coordinate < value + pull) {
+          position = index;
+        } else if (this.op(coordinate, '<', value)
+          && this.op(coordinate, '>', coordinates[index + 1] || value - width)) {
+          position = direction === 'left' ? index + 1 : index;
         }
+        return position === -1;
+      }, this));
+    }
 
-        return event;
-    };
+    if (!this.settings.loop) {
+      // non loop boundries
+      if (this.op(coordinate, '>', coordinates[this.minimum()])) {
+        position = coordinate = this.minimum();
+      } else if (this.op(coordinate, '<', coordinates[this.maximum()])) {
+        position = coordinate = this.maximum();
+      }
+    }
 
-    /**
-     * Enters a state.
-     * @param name - The state name.
-     */
-    Owl.prototype.enter = function (name) {
-        $.each([name].concat(this._states.tags[name] || []), $.proxy(function (i, name) {
-            if (this._states.current[name] === undefined) {
-                this._states.current[name] = 0;
-            }
+    return position;
+  };
 
-            this._states.current[name]++;
-        }, this));
-    };
+  /**
+   * Animates the stage.
+   * @todo #270
+   * @public
+   * @param {Number} coordinate - The coordinate in pixels.
+   */
+  Owl.prototype.animate = function(coordinate) {
+    var animate = this.speed() > 0;
 
-    /**
-     * Leaves a state.
-     * @param name - The state name.
-     */
-    Owl.prototype.leave = function (name) {
-        $.each([name].concat(this._states.tags[name] || []), $.proxy(function (i, name) {
-            this._states.current[name]--;
-        }, this));
-    };
+    this.is('animating') && this.onTransitionEnd();
 
-    /**
-     * Registers an event or state.
-     * @public
-     * @param {Object} object - The event or state to register.
-     */
-    Owl.prototype.register = function (object) {
-        if (object.type === Owl.Type.Event) {
-            if (!$.event.special[object.name]) {
-                $.event.special[object.name] = {};
-            }
+    if (animate) {
+      this.enter('animating');
+      this.trigger('translate');
+    }
 
-            if (!$.event.special[object.name].owl) {
-                var _default = $.event.special[object.name]._default;
-                $.event.special[object.name]._default = function (e) {
-                    if (_default && _default.apply && (!e.namespace || e.namespace.indexOf('owl') === -1)) {
-                        return _default.apply(this, arguments);
-                    }
-                    return e.namespace && e.namespace.indexOf('owl') > -1;
-                };
-                $.event.special[object.name].owl = true;
-            }
-        } else if (object.type === Owl.Type.State) {
-            if (!this._states.tags[object.name]) {
-                this._states.tags[object.name] = object.tags;
-            } else {
-                this._states.tags[object.name] = this._states.tags[object.name].concat(object.tags);
-            }
+    if ($.support.transform3d && $.support.transition) {
+      this.$stage.css({
+        transform: 'translate3d(' + coordinate + 'px,0px,0px)',
+        transition: (this.speed() / 1000) + 's'
+      });
+    } else if (animate) {
+      this.$stage.animate({
+        left: coordinate + 'px'
+      }, this.speed(), this.settings.fallbackEasing, $.proxy(this.onTransitionEnd, this));
+    } else {
+      this.$stage.css({
+        left: coordinate + 'px'
+      });
+    }
+  };
 
-            this._states.tags[object.name] = $.grep(this._states.tags[object.name], $.proxy(function (tag, i) {
-                return $.inArray(tag, this._states.tags[object.name]) === i;
-            }, this));
+  /**
+   * Checks whether the carousel is in a specific state or not.
+   * @param {String} state - The state to check.
+   * @returns {Boolean} - The flag which indicates if the carousel is busy.
+   */
+  Owl.prototype.is = function(state) {
+    return this._states.current[state] && this._states.current[state] > 0;
+  };
+
+  /**
+   * Sets the absolute position of the current item.
+   * @public
+   * @param {Number} [position] - The new absolute position or nothing to leave it unchanged.
+   * @returns {Number} - The absolute position of the current item.
+   */
+  Owl.prototype.current = function(position) {
+    if (position === undefined) {
+      return this._current;
+    }
+
+    if (this._items.length === 0) {
+      return undefined;
+    }
+
+    position = this.normalize(position);
+
+    if (this._current !== position) {
+      var event = this.trigger('change', { property: { name: 'position', value: position } });
+
+      if (event.data !== undefined) {
+        position = this.normalize(event.data);
+      }
+
+      this._current = position;
+
+      this.invalidate('position');
+
+      this.trigger('changed', { property: { name: 'position', value: this._current } });
+    }
+
+    return this._current;
+  };
+
+  /**
+   * Invalidates the given part of the update routine.
+   * @param {String} [part] - The part to invalidate.
+   * @returns {Array.<String>} - The invalidated parts.
+   */
+  Owl.prototype.invalidate = function(part) {
+    if ($.type(part) === 'string') {
+      this._invalidated[part] = true;
+      this.is('valid') && this.leave('valid');
+    }
+    return $.map(this._invalidated, function(v, i) { return i });
+  };
+
+  /**
+   * Resets the absolute position of the current item.
+   * @public
+   * @param {Number} position - The absolute position of the new item.
+   */
+  Owl.prototype.reset = function(position) {
+    position = this.normalize(position);
+
+    if (position === undefined) {
+      return;
+    }
+
+    this._speed = 0;
+    this._current = position;
+
+    this.suppress([ 'translate', 'translated' ]);
+
+    this.animate(this.coordinates(position));
+
+    this.release([ 'translate', 'translated' ]);
+  };
+
+  /**
+   * Normalizes an absolute or a relative position of an item.
+   * @public
+   * @param {Number} position - The absolute or relative position to normalize.
+   * @param {Boolean} [relative=false] - Whether the given position is relative or not.
+   * @returns {Number} - The normalized position.
+   */
+  Owl.prototype.normalize = function(position, relative) {
+    var n = this._items.length,
+      m = relative ? 0 : this._clones.length;
+
+    if (!$.isNumeric(position) || n < 1) {
+      position = undefined;
+    } else if (position < 0 || position >= n + m) {
+      position = ((position - m / 2) % n + n) % n + m / 2;
+    }
+
+    return position;
+  };
+
+  /**
+   * Converts an absolute position of an item into a relative one.
+   * @public
+   * @param {Number} position - The absolute position to convert.
+   * @returns {Number} - The converted position.
+   */
+  Owl.prototype.relative = function(position) {
+    position -= this._clones.length / 2;
+    return this.normalize(position, true);
+  };
+
+  /**
+   * Gets the maximum position for the current item.
+   * @public
+   * @param {Boolean} [relative=false] - Whether to return an absolute position or a relative position.
+   * @returns {Number}
+   */
+  Owl.prototype.maximum = function(relative) {
+    var settings = this.settings,
+      maximum = this._coordinates.length,
+      boundary = Math.abs(this._coordinates[maximum - 1]) - this._width,
+      i = -1, j;
+
+    if (settings.loop) {
+      maximum = this._clones.length / 2 + this._items.length - 1;
+    } else if (settings.autoWidth || settings.merge) {
+      // binary search
+      while (maximum - i > 1) {
+        Math.abs(this._coordinates[j = maximum + i >> 1]) < boundary
+          ? i = j : maximum = j;
+      }
+    } else if (settings.center) {
+      maximum = this._items.length - 1;
+    } else {
+      maximum = this._items.length - settings.items;
+    }
+
+    if (relative) {
+      maximum -= this._clones.length / 2;
+    }
+
+    return Math.max(maximum, 0);
+  };
+
+  /**
+   * Gets the minimum position for the current item.
+   * @public
+   * @param {Boolean} [relative=false] - Whether to return an absolute position or a relative position.
+   * @returns {Number}
+   */
+  Owl.prototype.minimum = function(relative) {
+    return relative ? 0 : this._clones.length / 2;
+  };
+
+  /**
+   * Gets an item at the specified relative position.
+   * @public
+   * @param {Number} [position] - The relative position of the item.
+   * @return {jQuery|Array.<jQuery>} - The item at the given position or all items if no position was given.
+   */
+  Owl.prototype.items = function(position) {
+    if (position === undefined) {
+      return this._items.slice();
+    }
+
+    position = this.normalize(position, true);
+    return this._items[position];
+  };
+
+  /**
+   * Gets an item at the specified relative position.
+   * @public
+   * @param {Number} [position] - The relative position of the item.
+   * @return {jQuery|Array.<jQuery>} - The item at the given position or all items if no position was given.
+   */
+  Owl.prototype.mergers = function(position) {
+    if (position === undefined) {
+      return this._mergers.slice();
+    }
+
+    position = this.normalize(position, true);
+    return this._mergers[position];
+  };
+
+  /**
+   * Gets the absolute positions of clones for an item.
+   * @public
+   * @param {Number} [position] - The relative position of the item.
+   * @returns {Array.<Number>} - The absolute positions of clones for the item or all if no position was given.
+   */
+  Owl.prototype.clones = function(position) {
+    var odd = this._clones.length / 2,
+      even = odd + this._items.length,
+      map = function(index) { return index % 2 === 0 ? even + index / 2 : odd - (index + 1) / 2 };
+
+    if (position === undefined) {
+      return $.map(this._clones, function(v, i) { return map(i) });
+    }
+
+    return $.map(this._clones, function(v, i) { return v === position ? map(i) : null });
+  };
+
+  /**
+   * Sets the current animation speed.
+   * @public
+   * @param {Number} [speed] - The animation speed in milliseconds or nothing to leave it unchanged.
+   * @returns {Number} - The current animation speed in milliseconds.
+   */
+  Owl.prototype.speed = function(speed) {
+    if (speed !== undefined) {
+      this._speed = speed;
+    }
+
+    return this._speed;
+  };
+
+  /**
+   * Gets the coordinate of an item.
+   * @todo The name of this method is missleanding.
+   * @public
+   * @param {Number} position - The absolute position of the item within `minimum()` and `maximum()`.
+   * @returns {Number|Array.<Number>} - The coordinate of the item in pixel or all coordinates.
+   */
+  Owl.prototype.coordinates = function(position) {
+    var coordinate = null;
+
+    if (position === undefined) {
+      return $.map(this._coordinates, $.proxy(function(coordinate, index) {
+        return this.coordinates(index);
+      }, this));
+    }
+
+    if (this.settings.center) {
+      coordinate = this._coordinates[position];
+      coordinate += (this.width() - coordinate + (this._coordinates[position - 1] || 0)) / 2 * (this.settings.rtl ? -1 : 1);
+    } else {
+      coordinate = this._coordinates[position - 1] || 0;
+    }
+
+    return coordinate;
+  };
+
+  /**
+   * Calculates the speed for a translation.
+   * @protected
+   * @param {Number} from - The absolute position of the start item.
+   * @param {Number} to - The absolute position of the target item.
+   * @param {Number} [factor=undefined] - The time factor in milliseconds.
+   * @returns {Number} - The time in milliseconds for the translation.
+   */
+  Owl.prototype.duration = function(from, to, factor) {
+    return Math.min(Math.max(Math.abs(to - from), 1), 6) * Math.abs((factor || this.settings.smartSpeed));
+  };
+
+  /**
+   * Slides to the specified item.
+   * @public
+   * @param {Number} position - The position of the item.
+   * @param {Number} [speed] - The time in milliseconds for the transition.
+   */
+  Owl.prototype.to = function(position, speed) {
+    var current = this.current(),
+      revert = null,
+      distance = position - this.relative(current),
+      direction = (distance > 0) - (distance < 0),
+      items = this._items.length,
+      minimum = this.minimum(),
+      maximum = this.maximum();
+
+    if (this.settings.loop) {
+      if (!this.settings.rewind && Math.abs(distance) > items / 2) {
+        distance += direction * -1 * items;
+      }
+
+      position = current + distance;
+      revert = ((position - minimum) % items + items) % items + minimum;
+
+      if (revert !== position && revert - distance <= maximum && revert - distance > 0) {
+        current = revert - distance;
+        position = revert;
+        this.reset(current);
+      }
+    } else if (this.settings.rewind) {
+      maximum += 1;
+      position = (position % maximum + maximum) % maximum;
+    } else {
+      position = Math.max(minimum, Math.min(maximum, position));
+    }
+
+    this.speed(this.duration(current, position, speed));
+    this.current(position);
+
+    if (this.$element.is(':visible')) {
+      this.update();
+    }
+  };
+
+  /**
+   * Slides to the next item.
+   * @public
+   * @param {Number} [speed] - The time in milliseconds for the transition.
+   */
+  Owl.prototype.next = function(speed) {
+    speed = speed || false;
+    this.to(this.relative(this.current()) + 1, speed);
+  };
+
+  /**
+   * Slides to the previous item.
+   * @public
+   * @param {Number} [speed] - The time in milliseconds for the transition.
+   */
+  Owl.prototype.prev = function(speed) {
+    speed = speed || false;
+    this.to(this.relative(this.current()) - 1, speed);
+  };
+
+  /**
+   * Handles the end of an animation.
+   * @protected
+   * @param {Event} event - The event arguments.
+   */
+  Owl.prototype.onTransitionEnd = function(event) {
+
+    // if css2 animation then event object is undefined
+    if (event !== undefined) {
+      event.stopPropagation();
+
+      // Catch only owl-stage transitionEnd event
+      if ((event.target || event.srcElement || event.originalTarget) !== this.$stage.get(0)) {
+        return false;
+      }
+    }
+
+    this.leave('animating');
+    this.trigger('translated');
+  };
+
+  /**
+   * Gets viewport width.
+   * @protected
+   * @return {Number} - The width in pixel.
+   */
+  Owl.prototype.viewport = function() {
+    var width;
+    if (this.options.responsiveBaseElement !== window) {
+      width = $(this.options.responsiveBaseElement).width();
+    } else if (window.innerWidth) {
+      width = window.innerWidth;
+    } else if (document.documentElement && document.documentElement.clientWidth) {
+      width = document.documentElement.clientWidth;
+    } else {
+      throw 'Can not detect viewport width.';
+    }
+    return width;
+  };
+
+  /**
+   * Replaces the current content.
+   * @public
+   * @param {HTMLElement|jQuery|String} content - The new content.
+   */
+  Owl.prototype.replace = function(content) {
+    this.$stage.empty();
+    this._items = [];
+
+    if (content) {
+      content = (content instanceof jQuery) ? content : $(content);
+    }
+
+    if (this.settings.nestedItemSelector) {
+      content = content.find('.' + this.settings.nestedItemSelector);
+    }
+
+    content.filter(function() {
+      return this.nodeType === 1;
+    }).each($.proxy(function(index, item) {
+      item = this.prepare(item);
+      this.$stage.append(item);
+      this._items.push(item);
+      this._mergers.push(item.find('[data-merge]').andSelf('[data-merge]').attr('data-merge') * 1 || 1);
+    }, this));
+
+    this.reset($.isNumeric(this.settings.startPosition) ? this.settings.startPosition : 0);
+
+    this.invalidate('items');
+  };
+
+  /**
+   * Adds an item.
+   * @todo Use `item` instead of `content` for the event arguments.
+   * @public
+   * @param {HTMLElement|jQuery|String} content - The item content to add.
+   * @param {Number} [position] - The relative position at which to insert the item otherwise the item will be added to the end.
+   */
+  Owl.prototype.add = function(content, position) {
+    var current = this.relative(this._current);
+
+    position = position === undefined ? this._items.length : this.normalize(position, true);
+    content = content instanceof jQuery ? content : $(content);
+
+    this.trigger('add', { content: content, position: position });
+
+    content = this.prepare(content);
+
+    if (this._items.length === 0 || position === this._items.length) {
+      this._items.length === 0 && this.$stage.append(content);
+      this._items.length !== 0 && this._items[position - 1].after(content);
+      this._items.push(content);
+      this._mergers.push(content.find('[data-merge]').andSelf('[data-merge]').attr('data-merge') * 1 || 1);
+    } else {
+      this._items[position].before(content);
+      this._items.splice(position, 0, content);
+      this._mergers.splice(position, 0, content.find('[data-merge]').andSelf('[data-merge]').attr('data-merge') * 1 || 1);
+    }
+
+    this._items[current] && this.reset(this._items[current].index());
+
+    this.invalidate('items');
+
+    this.trigger('added', { content: content, position: position });
+  };
+
+  /**
+   * Removes an item by its position.
+   * @todo Use `item` instead of `content` for the event arguments.
+   * @public
+   * @param {Number} position - The relative position of the item to remove.
+   */
+  Owl.prototype.remove = function(position) {
+    position = this.normalize(position, true);
+
+    if (position === undefined) {
+      return;
+    }
+
+    this.trigger('remove', { content: this._items[position], position: position });
+
+    this._items[position].remove();
+    this._items.splice(position, 1);
+    this._mergers.splice(position, 1);
+
+    this.invalidate('items');
+
+    this.trigger('removed', { content: null, position: position });
+  };
+
+  /**
+   * Preloads images with auto width.
+   * @todo Replace by a more generic approach
+   * @protected
+   */
+  Owl.prototype.preloadAutoWidthImages = function(images) {
+    images.each($.proxy(function(i, element) {
+      this.enter('pre-loading');
+      element = $(element);
+      $(new Image()).one('load', $.proxy(function(e) {
+        element.attr('src', e.target.src);
+        element.css('opacity', 1);
+        this.leave('pre-loading');
+        !this.is('pre-loading') && !this.is('initializing') && this.refresh();
+      }, this)).attr('src', element.attr('src') || element.attr('data-src') || element.attr('data-src-retina'));
+    }, this));
+  };
+
+  /**
+   * Destroys the carousel.
+   * @public
+   */
+  Owl.prototype.destroy = function() {
+
+    this.$element.off('.owl.core');
+    this.$stage.off('.owl.core');
+    $(document).off('.owl.core');
+
+    if (this.settings.responsive !== false) {
+      window.clearTimeout(this.resizeTimer);
+      this.off(window, 'resize', this._handlers.onThrottledResize);
+    }
+
+    for (var i in this._plugins) {
+      this._plugins[i].destroy();
+    }
+
+    this.$stage.children('.cloned').remove();
+
+    this.$stage.unwrap();
+    this.$stage.children().contents().unwrap();
+    this.$stage.children().unwrap();
+
+    this.$element
+      .removeClass(this.options.refreshClass)
+      .removeClass(this.options.loadingClass)
+      .removeClass(this.options.loadedClass)
+      .removeClass(this.options.rtlClass)
+      .removeClass(this.options.dragClass)
+      .removeClass(this.options.grabClass)
+      .attr('class', this.$element.attr('class').replace(new RegExp(this.options.responsiveClass + '-\\S+\\s', 'g'), ''))
+      .removeData('owl.carousel');
+  };
+
+  /**
+   * Operators to calculate right-to-left and left-to-right.
+   * @protected
+   * @param {Number} [a] - The left side operand.
+   * @param {String} [o] - The operator.
+   * @param {Number} [b] - The right side operand.
+   */
+  Owl.prototype.op = function(a, o, b) {
+    var rtl = this.settings.rtl;
+    switch (o) {
+      case '<':
+        return rtl ? a > b : a < b;
+      case '>':
+        return rtl ? a < b : a > b;
+      case '>=':
+        return rtl ? a <= b : a >= b;
+      case '<=':
+        return rtl ? a >= b : a <= b;
+      default:
+        break;
+    }
+  };
+
+  /**
+   * Attaches to an internal event.
+   * @protected
+   * @param {HTMLElement} element - The event source.
+   * @param {String} event - The event name.
+   * @param {Function} listener - The event handler to attach.
+   * @param {Boolean} capture - Wether the event should be handled at the capturing phase or not.
+   */
+  Owl.prototype.on = function(element, event, listener, capture) {
+    if (element.addEventListener) {
+      element.addEventListener(event, listener, capture);
+    } else if (element.attachEvent) {
+      element.attachEvent('on' + event, listener);
+    }
+  };
+
+  /**
+   * Detaches from an internal event.
+   * @protected
+   * @param {HTMLElement} element - The event source.
+   * @param {String} event - The event name.
+   * @param {Function} listener - The attached event handler to detach.
+   * @param {Boolean} capture - Wether the attached event handler was registered as a capturing listener or not.
+   */
+  Owl.prototype.off = function(element, event, listener, capture) {
+    if (element.removeEventListener) {
+      element.removeEventListener(event, listener, capture);
+    } else if (element.detachEvent) {
+      element.detachEvent('on' + event, listener);
+    }
+  };
+
+  /**
+   * Triggers a public event.
+   * @todo Remove `status`, `relatedTarget` should be used instead.
+   * @protected
+   * @param {String} name - The event name.
+   * @param {*} [data=null] - The event data.
+   * @param {String} [namespace=carousel] - The event namespace.
+   * @param {String} [state] - The state which is associated with the event.
+   * @param {Boolean} [enter=false] - Indicates if the call enters the specified state or not.
+   * @returns {Event} - The event arguments.
+   */
+  Owl.prototype.trigger = function(name, data, namespace, state, enter) {
+    var status = {
+      item: { count: this._items.length, index: this.current() }
+    }, handler = $.camelCase(
+      $.grep([ 'on', name, namespace ], function(v) { return v })
+        .join('-').toLowerCase()
+    ), event = $.Event(
+      [ name, 'owl', namespace || 'carousel' ].join('.').toLowerCase(),
+      $.extend({ relatedTarget: this }, status, data)
+    );
+
+    if (!this._supress[name]) {
+      $.each(this._plugins, function(name, plugin) {
+        if (plugin.onTrigger) {
+          plugin.onTrigger(event);
         }
-    };
+      });
 
-    /**
-     * Suppresses events.
-     * @protected
-     * @param {Array.<String>} events - The events to suppress.
-     */
-    Owl.prototype.suppress = function (events) {
-        $.each(events, $.proxy(function (index, event) {
-            this._supress[event] = true;
-        }, this));
-    };
+      this.register({ type: Owl.Type.Event, name: name });
+      this.$element.trigger(event);
 
-    /**
-     * Releases suppressed events.
-     * @protected
-     * @param {Array.<String>} events - The events to release.
-     */
-    Owl.prototype.release = function (events) {
-        $.each(events, $.proxy(function (index, event) {
-            delete this._supress[event];
-        }, this));
-    };
+      if (this.settings && typeof this.settings[handler] === 'function') {
+        this.settings[handler].call(this, event);
+      }
+    }
 
-    /**
-     * Gets unified pointer coordinates from event.
-     * @todo #261
-     * @protected
-     * @param {Event} - The `mousedown` or `touchstart` event.
-     * @returns {Object} - Contains `x` and `y` coordinates of current pointer position.
-     */
-    Owl.prototype.pointer = function (event) {
-        var result = { x: null, y: null };
+    return event;
+  };
 
-        event = event.originalEvent || event || window.event;
+  /**
+   * Enters a state.
+   * @param name - The state name.
+   */
+  Owl.prototype.enter = function(name) {
+    $.each([ name ].concat(this._states.tags[name] || []), $.proxy(function(i, name) {
+      if (this._states.current[name] === undefined) {
+        this._states.current[name] = 0;
+      }
 
-        event = event.touches && event.touches.length ?
-          event.touches[0] : event.changedTouches && event.changedTouches.length ?
-            event.changedTouches[0] : event;
+      this._states.current[name]++;
+    }, this));
+  };
 
-        if (event.pageX) {
-            result.x = event.pageX;
-            result.y = event.pageY;
-        } else {
-            result.x = event.clientX;
-            result.y = event.clientY;
-        }
+  /**
+   * Leaves a state.
+   * @param name - The state name.
+   */
+  Owl.prototype.leave = function(name) {
+    $.each([ name ].concat(this._states.tags[name] || []), $.proxy(function(i, name) {
+      this._states.current[name]--;
+    }, this));
+  };
 
-        return result;
-    };
+  /**
+   * Registers an event or state.
+   * @public
+   * @param {Object} object - The event or state to register.
+   */
+  Owl.prototype.register = function(object) {
+    if (object.type === Owl.Type.Event) {
+      if (!$.event.special[object.name]) {
+        $.event.special[object.name] = {};
+      }
 
-    /**
-     * Gets the difference of two vectors.
-     * @todo #261
-     * @protected
-     * @param {Object} - The first vector.
-     * @param {Object} - The second vector.
-     * @returns {Object} - The difference.
-     */
-    Owl.prototype.difference = function (first, second) {
-        return {
-            x: first.x - second.x,
-            y: first.y - second.y
+      if (!$.event.special[object.name].owl) {
+        var _default = $.event.special[object.name]._default;
+        $.event.special[object.name]._default = function(e) {
+          if (_default && _default.apply && (!e.namespace || e.namespace.indexOf('owl') === -1)) {
+            return _default.apply(this, arguments);
+          }
+          return e.namespace && e.namespace.indexOf('owl') > -1;
         };
+        $.event.special[object.name].owl = true;
+      }
+    } else if (object.type === Owl.Type.State) {
+      if (!this._states.tags[object.name]) {
+        this._states.tags[object.name] = object.tags;
+      } else {
+        this._states.tags[object.name] = this._states.tags[object.name].concat(object.tags);
+      }
+
+      this._states.tags[object.name] = $.grep(this._states.tags[object.name], $.proxy(function(tag, i) {
+        return $.inArray(tag, this._states.tags[object.name]) === i;
+      }, this));
+    }
+  };
+
+  /**
+   * Suppresses events.
+   * @protected
+   * @param {Array.<String>} events - The events to suppress.
+   */
+  Owl.prototype.suppress = function(events) {
+    $.each(events, $.proxy(function(index, event) {
+      this._supress[event] = true;
+    }, this));
+  };
+
+  /**
+   * Releases suppressed events.
+   * @protected
+   * @param {Array.<String>} events - The events to release.
+   */
+  Owl.prototype.release = function(events) {
+    $.each(events, $.proxy(function(index, event) {
+      delete this._supress[event];
+    }, this));
+  };
+
+  /**
+   * Gets unified pointer coordinates from event.
+   * @todo #261
+   * @protected
+   * @param {Event} - The `mousedown` or `touchstart` event.
+   * @returns {Object} - Contains `x` and `y` coordinates of current pointer position.
+   */
+  Owl.prototype.pointer = function(event) {
+    var result = { x: null, y: null };
+
+    event = event.originalEvent || event || window.event;
+
+    event = event.touches && event.touches.length ?
+      event.touches[0] : event.changedTouches && event.changedTouches.length ?
+        event.changedTouches[0] : event;
+
+    if (event.pageX) {
+      result.x = event.pageX;
+      result.y = event.pageY;
+    } else {
+      result.x = event.clientX;
+      result.y = event.clientY;
+    }
+
+    return result;
+  };
+
+  /**
+   * Gets the difference of two vectors.
+   * @todo #261
+   * @protected
+   * @param {Object} - The first vector.
+   * @param {Object} - The second vector.
+   * @returns {Object} - The difference.
+   */
+  Owl.prototype.difference = function(first, second) {
+    return {
+      x: first.x - second.x,
+      y: first.y - second.y
     };
+  };
 
-    /**
-     * The jQuery Plugin for the Owl Carousel
-     * @todo Navigation plugin `next` and `prev`
-     * @public
-     */
-    $.fn.owlCarousel = function (option) {
-        var args = Array.prototype.slice.call(arguments, 1);
+  /**
+   * The jQuery Plugin for the Owl Carousel
+   * @todo Navigation plugin `next` and `prev`
+   * @public
+   */
+  $.fn.owlCarousel = function(option) {
+    var args = Array.prototype.slice.call(arguments, 1);
 
-        return this.each(function () {
-            var $this = $(this),
-              data = $this.data('owl.carousel');
+    return this.each(function() {
+      var $this = $(this),
+        data = $this.data('owl.carousel');
 
-            if (!data) {
-                data = new Owl(this, typeof option == 'object' && option);
-                $this.data('owl.carousel', data);
+      if (!data) {
+        data = new Owl(this, typeof option == 'object' && option);
+        $this.data('owl.carousel', data);
 
-                $.each([
-                  'next', 'prev', 'to', 'destroy', 'refresh', 'replace', 'add', 'remove'
-                ], function (i, event) {
-                    data.register({ type: Owl.Type.Event, name: event });
-                    data.$element.on(event + '.owl.carousel.core', $.proxy(function (e) {
-                        if (e.namespace && e.relatedTarget !== this) {
-                            this.suppress([event]);
-                            data[event].apply(this, [].slice.call(arguments, 1));
-                            this.release([event]);
-                        }
-                    }, data));
-                });
+        $.each([
+          'next', 'prev', 'to', 'destroy', 'refresh', 'replace', 'add', 'remove'
+        ], function(i, event) {
+          data.register({ type: Owl.Type.Event, name: event });
+          data.$element.on(event + '.owl.carousel.core', $.proxy(function(e) {
+            if (e.namespace && e.relatedTarget !== this) {
+              this.suppress([ event ]);
+              data[event].apply(this, [].slice.call(arguments, 1));
+              this.release([ event ]);
             }
-
-            if (typeof option == 'string' && option.charAt(0) !== '_') {
-                data[option].apply(data, args);
-            }
+          }, data));
         });
-    };
+      }
 
-    /**
-     * The constructor for the jQuery Plugin
-     * @public
-     */
-    $.fn.owlCarousel.Constructor = Owl;
+      if (typeof option == 'string' && option.charAt(0) !== '_') {
+        data[option].apply(data, args);
+      }
+    });
+  };
+
+  /**
+   * The constructor for the jQuery Plugin
+   * @public
+   */
+  $.fn.owlCarousel.Constructor = Owl;
 
 })(window.Zepto || window.jQuery, window, document);
 
@@ -3659,108 +3659,108 @@ var fakewaffle = (function ($, fakewaffle) {
  * @author Artus Kolanowski
  * @license The MIT License (MIT)
  */
-; (function ($, window, document, undefined) {
+;(function($, window, document, undefined) {
+
+  /**
+   * Creates the auto refresh plugin.
+   * @class The Auto Refresh Plugin
+   * @param {Owl} carousel - The Owl Carousel
+   */
+  var AutoRefresh = function(carousel) {
+    /**
+     * Reference to the core.
+     * @protected
+     * @type {Owl}
+     */
+    this._core = carousel;
 
     /**
-     * Creates the auto refresh plugin.
-     * @class The Auto Refresh Plugin
-     * @param {Owl} carousel - The Owl Carousel
+     * Refresh interval.
+     * @protected
+     * @type {number}
      */
-    var AutoRefresh = function (carousel) {
-        /**
-         * Reference to the core.
-         * @protected
-         * @type {Owl}
-         */
-        this._core = carousel;
-
-        /**
-         * Refresh interval.
-         * @protected
-         * @type {number}
-         */
-        this._interval = null;
-
-        /**
-         * Whether the element is currently visible or not.
-         * @protected
-         * @type {Boolean}
-         */
-        this._visible = null;
-
-        /**
-         * All event handlers.
-         * @protected
-         * @type {Object}
-         */
-        this._handlers = {
-            'initialized.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._core.settings.autoRefresh) {
-                    this.watch();
-                }
-            }, this)
-        };
-
-        // set default options
-        this._core.options = $.extend({}, AutoRefresh.Defaults, this._core.options);
-
-        // register event handlers
-        this._core.$element.on(this._handlers);
-    };
+    this._interval = null;
 
     /**
-     * Default options.
-     * @public
+     * Whether the element is currently visible or not.
+     * @protected
+     * @type {Boolean}
      */
-    AutoRefresh.Defaults = {
-        autoRefresh: true,
-        autoRefreshInterval: 500
-    };
+    this._visible = null;
 
     /**
-     * Watches the element.
+     * All event handlers.
+     * @protected
+     * @type {Object}
      */
-    AutoRefresh.prototype.watch = function () {
-        if (this._interval) {
-            return;
+    this._handlers = {
+      'initialized.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._core.settings.autoRefresh) {
+          this.watch();
         }
-
-        this._visible = this._core.$element.is(':visible');
-        this._interval = window.setInterval($.proxy(this.refresh, this), this._core.settings.autoRefreshInterval);
+      }, this)
     };
 
-    /**
-     * Refreshes the element.
-     */
-    AutoRefresh.prototype.refresh = function () {
-        if (this._core.$element.is(':visible') === this._visible) {
-            return;
-        }
+    // set default options
+    this._core.options = $.extend({}, AutoRefresh.Defaults, this._core.options);
 
-        this._visible = !this._visible;
+    // register event handlers
+    this._core.$element.on(this._handlers);
+  };
 
-        this._core.$element.toggleClass('owl-hidden', !this._visible);
+  /**
+   * Default options.
+   * @public
+   */
+  AutoRefresh.Defaults = {
+    autoRefresh: true,
+    autoRefreshInterval: 500
+  };
 
-        this._visible && (this._core.invalidate('width') && this._core.refresh());
-    };
+  /**
+   * Watches the element.
+   */
+  AutoRefresh.prototype.watch = function() {
+    if (this._interval) {
+      return;
+    }
 
-    /**
-     * Destroys the plugin.
-     */
-    AutoRefresh.prototype.destroy = function () {
-        var handler, property;
+    this._visible = this._core.$element.is(':visible');
+    this._interval = window.setInterval($.proxy(this.refresh, this), this._core.settings.autoRefreshInterval);
+  };
 
-        window.clearInterval(this._interval);
+  /**
+   * Refreshes the element.
+   */
+  AutoRefresh.prototype.refresh = function() {
+    if (this._core.$element.is(':visible') === this._visible) {
+      return;
+    }
 
-        for (handler in this._handlers) {
-            this._core.$element.off(handler, this._handlers[handler]);
-        }
-        for (property in Object.getOwnPropertyNames(this)) {
-            typeof this[property] != 'function' && (this[property] = null);
-        }
-    };
+    this._visible = !this._visible;
 
-    $.fn.owlCarousel.Constructor.Plugins.AutoRefresh = AutoRefresh;
+    this._core.$element.toggleClass('owl-hidden', !this._visible);
+
+    this._visible && (this._core.invalidate('width') && this._core.refresh());
+  };
+
+  /**
+   * Destroys the plugin.
+   */
+  AutoRefresh.prototype.destroy = function() {
+    var handler, property;
+
+    window.clearInterval(this._interval);
+
+    for (handler in this._handlers) {
+      this._core.$element.off(handler, this._handlers[handler]);
+    }
+    for (property in Object.getOwnPropertyNames(this)) {
+      typeof this[property] != 'function' && (this[property] = null);
+    }
+  };
+
+  $.fn.owlCarousel.Constructor.Plugins.AutoRefresh = AutoRefresh;
 
 })(window.Zepto || window.jQuery, window, document);
 
@@ -3770,132 +3770,132 @@ var fakewaffle = (function ($, fakewaffle) {
  * @author Bartosz Wojciechowski
  * @license The MIT License (MIT)
  */
-; (function ($, window, document, undefined) {
+;(function($, window, document, undefined) {
+
+  /**
+   * Creates the lazy plugin.
+   * @class The Lazy Plugin
+   * @param {Owl} carousel - The Owl Carousel
+   */
+  var Lazy = function(carousel) {
 
     /**
-     * Creates the lazy plugin.
-     * @class The Lazy Plugin
-     * @param {Owl} carousel - The Owl Carousel
-     */
-    var Lazy = function (carousel) {
-
-        /**
-         * Reference to the core.
-         * @protected
-         * @type {Owl}
-         */
-        this._core = carousel;
-
-        /**
-         * Already loaded items.
-         * @protected
-         * @type {Array.<jQuery>}
-         */
-        this._loaded = [];
-
-        /**
-         * Event handlers.
-         * @protected
-         * @type {Object}
-         */
-        this._handlers = {
-            'initialized.owl.carousel change.owl.carousel': $.proxy(function (e) {
-                if (!e.namespace) {
-                    return;
-                }
-
-                if (!this._core.settings || !this._core.settings.lazyLoad) {
-                    return;
-                }
-
-                if ((e.property && e.property.name == 'position') || e.type == 'initialized') {
-                    var settings = this._core.settings,
-                      n = (settings.center && Math.ceil(settings.items / 2) || settings.items),
-                      i = ((settings.center && n * -1) || 0),
-                      position = ((e.property && e.property.value) || this._core.current()) + i,
-                      clones = this._core.clones().length,
-                      load = $.proxy(function (i, v) { this.load(v) }, this);
-
-                    while (i++ < n) {
-                        this.load(clones / 2 + this._core.relative(position));
-                        clones && $.each(this._core.clones(this._core.relative(position)), load);
-                        position++;
-                    }
-                }
-            }, this)
-        };
-
-        // set the default options
-        this._core.options = $.extend({}, Lazy.Defaults, this._core.options);
-
-        // register event handler
-        this._core.$element.on(this._handlers);
-    }
-
-    /**
-     * Default options.
-     * @public
-     */
-    Lazy.Defaults = {
-        lazyLoad: false
-    }
-
-    /**
-     * Loads all resources of an item at the specified position.
-     * @param {Number} position - The absolute position of the item.
+     * Reference to the core.
      * @protected
+     * @type {Owl}
      */
-    Lazy.prototype.load = function (position) {
-        var $item = this._core.$stage.children().eq(position),
-          $elements = $item && $item.find('.owl-lazy');
-
-        if (!$elements || $.inArray($item.get(0), this._loaded) > -1) {
-            return;
-        }
-
-        $elements.each($.proxy(function (index, element) {
-            var $element = $(element), image,
-              url = (window.devicePixelRatio > 1 && $element.attr('data-src-retina')) || $element.attr('data-src');
-
-            this._core.trigger('load', { element: $element, url: url }, 'lazy');
-
-            if ($element.is('img')) {
-                $element.one('load.owl.lazy', $.proxy(function () {
-                    $element.css('opacity', 1);
-                    this._core.trigger('loaded', { element: $element, url: url }, 'lazy');
-                }, this)).attr('src', url);
-            } else {
-                image = new Image();
-                image.onload = $.proxy(function () {
-                    $element.css({
-                        'background-image': 'url(' + url + ')',
-                        'opacity': '1'
-                    });
-                    this._core.trigger('loaded', { element: $element, url: url }, 'lazy');
-                }, this);
-                image.src = url;
-            }
-        }, this));
-
-        this._loaded.push($item.get(0));
-    }
+    this._core = carousel;
 
     /**
-     * Destroys the plugin.
-     * @public
+     * Already loaded items.
+     * @protected
+     * @type {Array.<jQuery>}
      */
-    Lazy.prototype.destroy = function () {
-        var handler, property;
+    this._loaded = [];
 
-        for (handler in this.handlers) {
-            this._core.$element.off(handler, this.handlers[handler]);
+    /**
+     * Event handlers.
+     * @protected
+     * @type {Object}
+     */
+    this._handlers = {
+      'initialized.owl.carousel change.owl.carousel': $.proxy(function(e) {
+        if (!e.namespace) {
+          return;
         }
-        for (property in Object.getOwnPropertyNames(this)) {
-            typeof this[property] != 'function' && (this[property] = null);
+
+        if (!this._core.settings || !this._core.settings.lazyLoad) {
+          return;
         }
+
+        if ((e.property && e.property.name == 'position') || e.type == 'initialized') {
+          var settings = this._core.settings,
+            n = (settings.center && Math.ceil(settings.items / 2) || settings.items),
+            i = ((settings.center && n * -1) || 0),
+            position = ((e.property && e.property.value) || this._core.current()) + i,
+            clones = this._core.clones().length,
+            load = $.proxy(function(i, v) { this.load(v) }, this);
+
+          while (i++ < n) {
+            this.load(clones / 2 + this._core.relative(position));
+            clones && $.each(this._core.clones(this._core.relative(position)), load);
+            position++;
+          }
+        }
+      }, this)
     };
 
-    $.fn.owlCarousel.Constructor.Plugins.Lazy = Lazy;
+    // set the default options
+    this._core.options = $.extend({}, Lazy.Defaults, this._core.options);
+
+    // register event handler
+    this._core.$element.on(this._handlers);
+  }
+
+  /**
+   * Default options.
+   * @public
+   */
+  Lazy.Defaults = {
+    lazyLoad: false
+  }
+
+  /**
+   * Loads all resources of an item at the specified position.
+   * @param {Number} position - The absolute position of the item.
+   * @protected
+   */
+  Lazy.prototype.load = function(position) {
+    var $item = this._core.$stage.children().eq(position),
+      $elements = $item && $item.find('.owl-lazy');
+
+    if (!$elements || $.inArray($item.get(0), this._loaded) > -1) {
+      return;
+    }
+
+    $elements.each($.proxy(function(index, element) {
+      var $element = $(element), image,
+        url = (window.devicePixelRatio > 1 && $element.attr('data-src-retina')) || $element.attr('data-src');
+
+      this._core.trigger('load', { element: $element, url: url }, 'lazy');
+
+      if ($element.is('img')) {
+        $element.one('load.owl.lazy', $.proxy(function() {
+          $element.css('opacity', 1);
+          this._core.trigger('loaded', { element: $element, url: url }, 'lazy');
+        }, this)).attr('src', url);
+      } else {
+        image = new Image();
+        image.onload = $.proxy(function() {
+          $element.css({
+            'background-image': 'url(' + url + ')',
+            'opacity': '1'
+          });
+          this._core.trigger('loaded', { element: $element, url: url }, 'lazy');
+        }, this);
+        image.src = url;
+      }
+    }, this));
+
+    this._loaded.push($item.get(0));
+  }
+
+  /**
+   * Destroys the plugin.
+   * @public
+   */
+  Lazy.prototype.destroy = function() {
+    var handler, property;
+
+    for (handler in this.handlers) {
+      this._core.$element.off(handler, this.handlers[handler]);
+    }
+    for (property in Object.getOwnPropertyNames(this)) {
+      typeof this[property] != 'function' && (this[property] = null);
+    }
+  };
+
+  $.fn.owlCarousel.Constructor.Plugins.Lazy = Lazy;
 
 })(window.Zepto || window.jQuery, window, document);
 
@@ -3905,94 +3905,94 @@ var fakewaffle = (function ($, fakewaffle) {
  * @author Bartosz Wojciechowski
  * @license The MIT License (MIT)
  */
-; (function ($, window, document, undefined) {
+;(function($, window, document, undefined) {
+
+  /**
+   * Creates the auto height plugin.
+   * @class The Auto Height Plugin
+   * @param {Owl} carousel - The Owl Carousel
+   */
+  var AutoHeight = function(carousel) {
+    /**
+     * Reference to the core.
+     * @protected
+     * @type {Owl}
+     */
+    this._core = carousel;
 
     /**
-     * Creates the auto height plugin.
-     * @class The Auto Height Plugin
-     * @param {Owl} carousel - The Owl Carousel
+     * All event handlers.
+     * @protected
+     * @type {Object}
      */
-    var AutoHeight = function (carousel) {
-        /**
-         * Reference to the core.
-         * @protected
-         * @type {Owl}
-         */
-        this._core = carousel;
-
-        /**
-         * All event handlers.
-         * @protected
-         * @type {Object}
-         */
-        this._handlers = {
-            'initialized.owl.carousel refreshed.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._core.settings.autoHeight) {
-                    this.update();
-                }
-            }, this),
-            'changed.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._core.settings.autoHeight && e.property.name == 'position') {
-                    this.update();
-                }
-            }, this),
-            'loaded.owl.lazy': $.proxy(function (e) {
-                if (e.namespace && this._core.settings.autoHeight
-                  && e.element.closest('.' + this._core.settings.itemClass).index() === this._core.current()) {
-                    this.update();
-                }
-            }, this)
-        };
-
-        // set default options
-        this._core.options = $.extend({}, AutoHeight.Defaults, this._core.options);
-
-        // register event handlers
-        this._core.$element.on(this._handlers);
-    };
-
-    /**
-     * Default options.
-     * @public
-     */
-    AutoHeight.Defaults = {
-        autoHeight: false,
-        autoHeightClass: 'owl-height'
-    };
-
-    /**
-     * Updates the view.
-     */
-    AutoHeight.prototype.update = function () {
-        var start = this._core._current,
-          end = start + this._core.settings.items,
-          visible = this._core.$stage.children().toArray().slice(start, end);
-        heights = [],
-        maxheight = 0;
-
-        $.each(visible, function (index, item) {
-            heights.push($(item).height());
-        });
-
-        maxheight = Math.max.apply(null, heights);
-
-        this._core.$stage.parent()
-          .height(maxheight)
-          .addClass(this._core.settings.autoHeightClass);
-    };
-
-    AutoHeight.prototype.destroy = function () {
-        var handler, property;
-
-        for (handler in this._handlers) {
-            this._core.$element.off(handler, this._handlers[handler]);
+    this._handlers = {
+      'initialized.owl.carousel refreshed.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._core.settings.autoHeight) {
+          this.update();
         }
-        for (property in Object.getOwnPropertyNames(this)) {
-            typeof this[property] != 'function' && (this[property] = null);
+      }, this),
+      'changed.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._core.settings.autoHeight && e.property.name == 'position'){
+          this.update();
         }
+      }, this),
+      'loaded.owl.lazy': $.proxy(function(e) {
+        if (e.namespace && this._core.settings.autoHeight
+          && e.element.closest('.' + this._core.settings.itemClass).index() === this._core.current()) {
+          this.update();
+        }
+      }, this)
     };
 
-    $.fn.owlCarousel.Constructor.Plugins.AutoHeight = AutoHeight;
+    // set default options
+    this._core.options = $.extend({}, AutoHeight.Defaults, this._core.options);
+
+    // register event handlers
+    this._core.$element.on(this._handlers);
+  };
+
+  /**
+   * Default options.
+   * @public
+   */
+  AutoHeight.Defaults = {
+    autoHeight: false,
+    autoHeightClass: 'owl-height'
+  };
+
+  /**
+   * Updates the view.
+   */
+  AutoHeight.prototype.update = function() {
+    var start = this._core._current,
+      end = start + this._core.settings.items,
+      visible = this._core.$stage.children().toArray().slice(start, end);
+      heights = [],
+      maxheight = 0;
+
+    $.each(visible, function(index, item) {
+      heights.push($(item).height());
+    });
+
+    maxheight = Math.max.apply(null, heights);
+
+    this._core.$stage.parent()
+      .height(maxheight)
+      .addClass(this._core.settings.autoHeightClass);
+  };
+
+  AutoHeight.prototype.destroy = function() {
+    var handler, property;
+
+    for (handler in this._handlers) {
+      this._core.$element.off(handler, this._handlers[handler]);
+    }
+    for (property in Object.getOwnPropertyNames(this)) {
+      typeof this[property] != 'function' && (this[property] = null);
+    }
+  };
+
+  $.fn.owlCarousel.Constructor.Plugins.AutoHeight = AutoHeight;
 
 })(window.Zepto || window.jQuery, window, document);
 
@@ -4002,278 +4002,278 @@ var fakewaffle = (function ($, fakewaffle) {
  * @author Bartosz Wojciechowski
  * @license The MIT License (MIT)
  */
-; (function ($, window, document, undefined) {
+;(function($, window, document, undefined) {
 
+  /**
+   * Creates the video plugin.
+   * @class The Video Plugin
+   * @param {Owl} carousel - The Owl Carousel
+   */
+  var Video = function(carousel) {
     /**
-     * Creates the video plugin.
-     * @class The Video Plugin
-     * @param {Owl} carousel - The Owl Carousel
-     */
-    var Video = function (carousel) {
-        /**
-         * Reference to the core.
-         * @protected
-         * @type {Owl}
-         */
-        this._core = carousel;
-
-        /**
-         * Cache all video URLs.
-         * @protected
-         * @type {Object}
-         */
-        this._videos = {};
-
-        /**
-         * Current playing item.
-         * @protected
-         * @type {jQuery}
-         */
-        this._playing = null;
-
-        /**
-         * All event handlers.
-         * @todo The cloned content removale is too late
-         * @protected
-         * @type {Object}
-         */
-        this._handlers = {
-            'initialized.owl.carousel': $.proxy(function (e) {
-                if (e.namespace) {
-                    this._core.register({ type: 'state', name: 'playing', tags: ['interacting'] });
-                }
-            }, this),
-            'resize.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._core.settings.video && this.isInFullScreen()) {
-                    e.preventDefault();
-                }
-            }, this),
-            'refreshed.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._core.is('resizing')) {
-                    this._core.$stage.find('.cloned .owl-video-frame').remove();
-                }
-            }, this),
-            'changed.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && e.property.name === 'position' && this._playing) {
-                    this.stop();
-                }
-            }, this),
-            'prepared.owl.carousel': $.proxy(function (e) {
-                if (!e.namespace) {
-                    return;
-                }
-
-                var $element = $(e.content).find('.owl-video');
-
-                if ($element.length) {
-                    $element.css('display', 'none');
-                    this.fetch($element, $(e.content));
-                }
-            }, this)
-        };
-
-        // set default options
-        this._core.options = $.extend({}, Video.Defaults, this._core.options);
-
-        // register event handlers
-        this._core.$element.on(this._handlers);
-
-        this._core.$element.on('click.owl.video', '.owl-video-play-icon', $.proxy(function (e) {
-            this.play(e);
-        }, this));
-    };
-
-    /**
-     * Default options.
-     * @public
-     */
-    Video.Defaults = {
-        video: false,
-        videoHeight: false,
-        videoWidth: false
-    };
-
-    /**
-     * Gets the video ID and the type (YouTube/Vimeo only).
+     * Reference to the core.
      * @protected
-     * @param {jQuery} target - The target containing the video data.
-     * @param {jQuery} item - The item containing the video.
+     * @type {Owl}
      */
-    Video.prototype.fetch = function (target, item) {
-        var type = target.attr('data-vimeo-id') ? 'vimeo' : 'youtube',
-          id = target.attr('data-vimeo-id') || target.attr('data-youtube-id'),
-          width = target.attr('data-width') || this._core.settings.videoWidth,
-          height = target.attr('data-height') || this._core.settings.videoHeight,
-          url = target.attr('href');
+    this._core = carousel;
 
-        if (url) {
-            id = url.match(/(http:|https:|)\/\/(player.|www.)?(vimeo\.com|youtu(be\.com|\.be|be\.googleapis\.com))\/(video\/|embed\/|watch\?v=|v\/)?([A-Za-z0-9._%-]*)(\&\S+)?/);
+    /**
+     * Cache all video URLs.
+     * @protected
+     * @type {Object}
+     */
+    this._videos = {};
 
-            if (id[3].indexOf('youtu') > -1) {
-                type = 'youtube';
-            } else if (id[3].indexOf('vimeo') > -1) {
-                type = 'vimeo';
-            } else {
-                throw new Error('Video URL not supported.');
-            }
-            id = id[6];
+    /**
+     * Current playing item.
+     * @protected
+     * @type {jQuery}
+     */
+    this._playing = null;
+
+    /**
+     * All event handlers.
+     * @todo The cloned content removale is too late
+     * @protected
+     * @type {Object}
+     */
+    this._handlers = {
+      'initialized.owl.carousel': $.proxy(function(e) {
+        if (e.namespace) {
+          this._core.register({ type: 'state', name: 'playing', tags: [ 'interacting' ] });
+        }
+      }, this),
+      'resize.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._core.settings.video && this.isInFullScreen()) {
+          e.preventDefault();
+        }
+      }, this),
+      'refreshed.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._core.is('resizing')) {
+          this._core.$stage.find('.cloned .owl-video-frame').remove();
+        }
+      }, this),
+      'changed.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && e.property.name === 'position' && this._playing) {
+          this.stop();
+        }
+      }, this),
+      'prepared.owl.carousel': $.proxy(function(e) {
+        if (!e.namespace) {
+          return;
+        }
+
+        var $element = $(e.content).find('.owl-video');
+
+        if ($element.length) {
+          $element.css('display', 'none');
+          this.fetch($element, $(e.content));
+        }
+      }, this)
+    };
+
+    // set default options
+    this._core.options = $.extend({}, Video.Defaults, this._core.options);
+
+    // register event handlers
+    this._core.$element.on(this._handlers);
+
+    this._core.$element.on('click.owl.video', '.owl-video-play-icon', $.proxy(function(e) {
+      this.play(e);
+    }, this));
+  };
+
+  /**
+   * Default options.
+   * @public
+   */
+  Video.Defaults = {
+    video: false,
+    videoHeight: false,
+    videoWidth: false
+  };
+
+  /**
+   * Gets the video ID and the type (YouTube/Vimeo only).
+   * @protected
+   * @param {jQuery} target - The target containing the video data.
+   * @param {jQuery} item - The item containing the video.
+   */
+  Video.prototype.fetch = function(target, item) {
+    var type = target.attr('data-vimeo-id') ? 'vimeo' : 'youtube',
+      id = target.attr('data-vimeo-id') || target.attr('data-youtube-id'),
+      width = target.attr('data-width') || this._core.settings.videoWidth,
+      height = target.attr('data-height') || this._core.settings.videoHeight,
+      url = target.attr('href');
+
+    if (url) {
+      id = url.match(/(http:|https:|)\/\/(player.|www.)?(vimeo\.com|youtu(be\.com|\.be|be\.googleapis\.com))\/(video\/|embed\/|watch\?v=|v\/)?([A-Za-z0-9._%-]*)(\&\S+)?/);
+
+      if (id[3].indexOf('youtu') > -1) {
+        type = 'youtube';
+      } else if (id[3].indexOf('vimeo') > -1) {
+        type = 'vimeo';
+      } else {
+        throw new Error('Video URL not supported.');
+      }
+      id = id[6];
+    } else {
+      throw new Error('Missing video URL.');
+    }
+
+    this._videos[url] = {
+      type: type,
+      id: id,
+      width: width,
+      height: height
+    };
+
+    item.attr('data-video', url);
+
+    this.thumbnail(target, this._videos[url]);
+  };
+
+  /**
+   * Creates video thumbnail.
+   * @protected
+   * @param {jQuery} target - The target containing the video data.
+   * @param {Object} info - The video info object.
+   * @see `fetch`
+   */
+  Video.prototype.thumbnail = function(target, video) {
+    var tnLink,
+      icon,
+      path,
+      dimensions = video.width && video.height ? 'style="width:' + video.width + 'px;height:' + video.height + 'px;"' : '',
+      customTn = target.find('img'),
+      srcType = 'src',
+      lazyClass = '',
+      settings = this._core.settings,
+      create = function(path) {
+        icon = '<div class="owl-video-play-icon"></div>';
+
+        if (settings.lazyLoad) {
+          tnLink = '<div class="owl-video-tn ' + lazyClass + '" ' + srcType + '="' + path + '"></div>';
         } else {
-            throw new Error('Missing video URL.');
+          tnLink = '<div class="owl-video-tn" style="opacity:1;background-image:url(' + path + ')"></div>';
         }
+        target.after(tnLink);
+        target.after(icon);
+      };
 
-        this._videos[url] = {
-            type: type,
-            id: id,
-            width: width,
-            height: height
-        };
+    // wrap video content into owl-video-wrapper div
+    target.wrap('<div class="owl-video-wrapper"' + dimensions + '></div>');
 
-        item.attr('data-video', url);
+    if (this._core.settings.lazyLoad) {
+      srcType = 'data-src';
+      lazyClass = 'owl-lazy';
+    }
 
-        this.thumbnail(target, this._videos[url]);
-    };
+    // custom thumbnail
+    if (customTn.length) {
+      create(customTn.attr(srcType));
+      customTn.remove();
+      return false;
+    }
 
-    /**
-     * Creates video thumbnail.
-     * @protected
-     * @param {jQuery} target - The target containing the video data.
-     * @param {Object} info - The video info object.
-     * @see `fetch`
-     */
-    Video.prototype.thumbnail = function (target, video) {
-        var tnLink,
-          icon,
-          path,
-          dimensions = video.width && video.height ? 'style="width:' + video.width + 'px;height:' + video.height + 'px;"' : '',
-          customTn = target.find('img'),
-          srcType = 'src',
-          lazyClass = '',
-          settings = this._core.settings,
-          create = function (path) {
-              icon = '<div class="owl-video-play-icon"></div>';
-
-              if (settings.lazyLoad) {
-                  tnLink = '<div class="owl-video-tn ' + lazyClass + '" ' + srcType + '="' + path + '"></div>';
-              } else {
-                  tnLink = '<div class="owl-video-tn" style="opacity:1;background-image:url(' + path + ')"></div>';
-              }
-              target.after(tnLink);
-              target.after(icon);
-          };
-
-        // wrap video content into owl-video-wrapper div
-        target.wrap('<div class="owl-video-wrapper"' + dimensions + '></div>');
-
-        if (this._core.settings.lazyLoad) {
-            srcType = 'data-src';
-            lazyClass = 'owl-lazy';
+    if (video.type === 'youtube') {
+      path = "http://img.youtube.com/vi/" + video.id + "/hqdefault.jpg";
+      create(path);
+    } else if (video.type === 'vimeo') {
+      $.ajax({
+        type: 'GET',
+        url: 'http://vimeo.com/api/v2/video/' + video.id + '.json',
+        jsonp: 'callback',
+        dataType: 'jsonp',
+        success: function(data) {
+          path = data[0].thumbnail_large;
+          create(path);
         }
+      });
+    }
+  };
 
-        // custom thumbnail
-        if (customTn.length) {
-            create(customTn.attr(srcType));
-            customTn.remove();
-            return false;
-        }
+  /**
+   * Stops the current video.
+   * @public
+   */
+  Video.prototype.stop = function() {
+    this._core.trigger('stop', null, 'video');
+    this._playing.find('.owl-video-frame').remove();
+    this._playing.removeClass('owl-video-playing');
+    this._playing = null;
+    this._core.leave('playing');
+    this._core.trigger('stopped', null, 'video');
+  };
 
-        if (video.type === 'youtube') {
-            path = "http://img.youtube.com/vi/" + video.id + "/hqdefault.jpg";
-            create(path);
-        } else if (video.type === 'vimeo') {
-            $.ajax({
-                type: 'GET',
-                url: 'http://vimeo.com/api/v2/video/' + video.id + '.json',
-                jsonp: 'callback',
-                dataType: 'jsonp',
-                success: function (data) {
-                    path = data[0].thumbnail_large;
-                    create(path);
-                }
-            });
-        }
-    };
+  /**
+   * Starts the current video.
+   * @public
+   * @param {Event} event - The event arguments.
+   */
+  Video.prototype.play = function(event) {
+    var target = $(event.target),
+      item = target.closest('.' + this._core.settings.itemClass),
+      video = this._videos[item.attr('data-video')],
+      width = video.width || '100%',
+      height = video.height || this._core.$stage.height(),
+      html;
 
-    /**
-     * Stops the current video.
-     * @public
-     */
-    Video.prototype.stop = function () {
-        this._core.trigger('stop', null, 'video');
-        this._playing.find('.owl-video-frame').remove();
-        this._playing.removeClass('owl-video-playing');
-        this._playing = null;
-        this._core.leave('playing');
-        this._core.trigger('stopped', null, 'video');
-    };
+    if (this._playing) {
+      return;
+    }
 
-    /**
-     * Starts the current video.
-     * @public
-     * @param {Event} event - The event arguments.
-     */
-    Video.prototype.play = function (event) {
-        var target = $(event.target),
-          item = target.closest('.' + this._core.settings.itemClass),
-          video = this._videos[item.attr('data-video')],
-          width = video.width || '100%',
-          height = video.height || this._core.$stage.height(),
-          html;
+    this._core.enter('playing');
+    this._core.trigger('play', null, 'video');
 
-        if (this._playing) {
-            return;
-        }
+    item = this._core.items(this._core.relative(item.index()));
 
-        this._core.enter('playing');
-        this._core.trigger('play', null, 'video');
+    this._core.reset(item.index());
 
-        item = this._core.items(this._core.relative(item.index()));
+    if (video.type === 'youtube') {
+      html = '<iframe width="' + width + '" height="' + height + '" src="http://www.youtube.com/embed/' +
+        video.id + '?autoplay=1&v=' + video.id + '" frameborder="0" allowfullscreen></iframe>';
+    } else if (video.type === 'vimeo') {
+      html = '<iframe src="http://player.vimeo.com/video/' + video.id +
+        '?autoplay=1" width="' + width + '" height="' + height +
+        '" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>';
+    }
 
-        this._core.reset(item.index());
+    $('<div class="owl-video-frame">' + html + '</div>').insertAfter(item.find('.owl-video'));
 
-        if (video.type === 'youtube') {
-            html = '<iframe width="' + width + '" height="' + height + '" src="http://www.youtube.com/embed/' +
-              video.id + '?autoplay=1&v=' + video.id + '" frameborder="0" allowfullscreen></iframe>';
-        } else if (video.type === 'vimeo') {
-            html = '<iframe src="http://player.vimeo.com/video/' + video.id +
-              '?autoplay=1" width="' + width + '" height="' + height +
-              '" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>';
-        }
+    this._playing = item.addClass('owl-video-playing');
+  };
 
-        $('<div class="owl-video-frame">' + html + '</div>').insertAfter(item.find('.owl-video'));
+  /**
+   * Checks whether an video is currently in full screen mode or not.
+   * @todo Bad style because looks like a readonly method but changes members.
+   * @protected
+   * @returns {Boolean}
+   */
+  Video.prototype.isInFullScreen = function() {
+    var element = document.fullscreenElement || document.mozFullScreenElement ||
+        document.webkitFullscreenElement;
 
-        this._playing = item.addClass('owl-video-playing');
-    };
+    return element && $(element).parent().hasClass('owl-video-frame');
+  };
 
-    /**
-     * Checks whether an video is currently in full screen mode or not.
-     * @todo Bad style because looks like a readonly method but changes members.
-     * @protected
-     * @returns {Boolean}
-     */
-    Video.prototype.isInFullScreen = function () {
-        var element = document.fullscreenElement || document.mozFullScreenElement ||
-            document.webkitFullscreenElement;
+  /**
+   * Destroys the plugin.
+   */
+  Video.prototype.destroy = function() {
+    var handler, property;
 
-        return element && $(element).parent().hasClass('owl-video-frame');
-    };
+    this._core.$element.off('click.owl.video');
 
-    /**
-     * Destroys the plugin.
-     */
-    Video.prototype.destroy = function () {
-        var handler, property;
+    for (handler in this._handlers) {
+      this._core.$element.off(handler, this._handlers[handler]);
+    }
+    for (property in Object.getOwnPropertyNames(this)) {
+      typeof this[property] != 'function' && (this[property] = null);
+    }
+  };
 
-        this._core.$element.off('click.owl.video');
-
-        for (handler in this._handlers) {
-            this._core.$element.off(handler, this._handlers[handler]);
-        }
-        for (property in Object.getOwnPropertyNames(this)) {
-            typeof this[property] != 'function' && (this[property] = null);
-        }
-    };
-
-    $.fn.owlCarousel.Constructor.Plugins.Video = Video;
+  $.fn.owlCarousel.Constructor.Plugins.Video = Video;
 
 })(window.Zepto || window.jQuery, window, document);
 
@@ -4283,118 +4283,118 @@ var fakewaffle = (function ($, fakewaffle) {
  * @author Bartosz Wojciechowski
  * @license The MIT License (MIT)
  */
-; (function ($, window, document, undefined) {
+;(function($, window, document, undefined) {
 
-    /**
-     * Creates the animate plugin.
-     * @class The Navigation Plugin
-     * @param {Owl} scope - The Owl Carousel
-     */
-    var Animate = function (scope) {
-        this.core = scope;
-        this.core.options = $.extend({}, Animate.Defaults, this.core.options);
-        this.swapping = true;
-        this.previous = undefined;
-        this.next = undefined;
+  /**
+   * Creates the animate plugin.
+   * @class The Navigation Plugin
+   * @param {Owl} scope - The Owl Carousel
+   */
+  var Animate = function(scope) {
+    this.core = scope;
+    this.core.options = $.extend({}, Animate.Defaults, this.core.options);
+    this.swapping = true;
+    this.previous = undefined;
+    this.next = undefined;
 
-        this.handlers = {
-            'change.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && e.property.name == 'position') {
-                    this.previous = this.core.current();
-                    this.next = e.property.value;
-                }
-            }, this),
-            'drag.owl.carousel dragged.owl.carousel translated.owl.carousel': $.proxy(function (e) {
-                if (e.namespace) {
-                    this.swapping = e.type == 'translated';
-                }
-            }, this),
-            'translate.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this.swapping && (this.core.options.animateOut || this.core.options.animateIn)) {
-                    this.swap();
-                }
-            }, this)
-        };
-
-        this.core.$element.on(this.handlers);
+    this.handlers = {
+      'change.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && e.property.name == 'position') {
+          this.previous = this.core.current();
+          this.next = e.property.value;
+        }
+      }, this),
+      'drag.owl.carousel dragged.owl.carousel translated.owl.carousel': $.proxy(function(e) {
+        if (e.namespace) {
+          this.swapping = e.type == 'translated';
+        }
+      }, this),
+      'translate.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this.swapping && (this.core.options.animateOut || this.core.options.animateIn)) {
+          this.swap();
+        }
+      }, this)
     };
 
-    /**
-     * Default options.
-     * @public
-     */
-    Animate.Defaults = {
-        animateOut: false,
-        animateIn: false
-    };
+    this.core.$element.on(this.handlers);
+  };
 
-    /**
-     * Toggles the animation classes whenever an translations starts.
-     * @protected
-     * @returns {Boolean|undefined}
-     */
-    Animate.prototype.swap = function () {
+  /**
+   * Default options.
+   * @public
+   */
+  Animate.Defaults = {
+    animateOut: false,
+    animateIn: false
+  };
 
-        if (this.core.settings.items !== 1) {
-            return;
-        }
+  /**
+   * Toggles the animation classes whenever an translations starts.
+   * @protected
+   * @returns {Boolean|undefined}
+   */
+  Animate.prototype.swap = function() {
 
-        if (!$.support.animation || !$.support.transition) {
-            return;
-        }
+    if (this.core.settings.items !== 1) {
+      return;
+    }
 
-        this.core.speed(0);
+    if (!$.support.animation || !$.support.transition) {
+      return;
+    }
 
-        var left,
-          clear = $.proxy(this.clear, this),
-          previous = this.core.$stage.children().eq(this.previous),
-          next = this.core.$stage.children().eq(this.next),
-          incoming = this.core.settings.animateIn,
-          outgoing = this.core.settings.animateOut;
+    this.core.speed(0);
 
-        if (this.core.current() === this.previous) {
-            return;
-        }
+    var left,
+      clear = $.proxy(this.clear, this),
+      previous = this.core.$stage.children().eq(this.previous),
+      next = this.core.$stage.children().eq(this.next),
+      incoming = this.core.settings.animateIn,
+      outgoing = this.core.settings.animateOut;
 
-        if (outgoing) {
-            left = this.core.coordinates(this.previous) - this.core.coordinates(this.next);
-            previous.one($.support.animation.end, clear)
-              .css({ 'left': left + 'px' })
-              .addClass('animated owl-animated-out')
-              .addClass(outgoing);
-        }
+    if (this.core.current() === this.previous) {
+      return;
+    }
 
-        if (incoming) {
-            next.one($.support.animation.end, clear)
-              .addClass('animated owl-animated-in')
-              .addClass(incoming);
-        }
-    };
+    if (outgoing) {
+      left = this.core.coordinates(this.previous) - this.core.coordinates(this.next);
+      previous.one($.support.animation.end, clear)
+        .css( { 'left': left + 'px' } )
+        .addClass('animated owl-animated-out')
+        .addClass(outgoing);
+    }
 
-    Animate.prototype.clear = function (e) {
-        $(e.target).css({ 'left': '' })
-          .removeClass('animated owl-animated-out owl-animated-in')
-          .removeClass(this.core.settings.animateIn)
-          .removeClass(this.core.settings.animateOut);
-        this.core.onTransitionEnd();
-    };
+    if (incoming) {
+      next.one($.support.animation.end, clear)
+        .addClass('animated owl-animated-in')
+        .addClass(incoming);
+    }
+  };
 
-    /**
-     * Destroys the plugin.
-     * @public
-     */
-    Animate.prototype.destroy = function () {
-        var handler, property;
+  Animate.prototype.clear = function(e) {
+    $(e.target).css( { 'left': '' } )
+      .removeClass('animated owl-animated-out owl-animated-in')
+      .removeClass(this.core.settings.animateIn)
+      .removeClass(this.core.settings.animateOut);
+    this.core.onTransitionEnd();
+  };
 
-        for (handler in this.handlers) {
-            this.core.$element.off(handler, this.handlers[handler]);
-        }
-        for (property in Object.getOwnPropertyNames(this)) {
-            typeof this[property] != 'function' && (this[property] = null);
-        }
-    };
+  /**
+   * Destroys the plugin.
+   * @public
+   */
+  Animate.prototype.destroy = function() {
+    var handler, property;
 
-    $.fn.owlCarousel.Constructor.Plugins.Animate = Animate;
+    for (handler in this.handlers) {
+      this.core.$element.off(handler, this.handlers[handler]);
+    }
+    for (property in Object.getOwnPropertyNames(this)) {
+      typeof this[property] != 'function' && (this[property] = null);
+    }
+  };
+
+  $.fn.owlCarousel.Constructor.Plugins.Animate = Animate;
 
 })(window.Zepto || window.jQuery, window, document);
 
@@ -4405,158 +4405,158 @@ var fakewaffle = (function ($, fakewaffle) {
  * @author Artus Kolanowski
  * @license The MIT License (MIT)
  */
-; (function ($, window, document, undefined) {
+;(function($, window, document, undefined) {
+
+  /**
+   * Creates the autoplay plugin.
+   * @class The Autoplay Plugin
+   * @param {Owl} scope - The Owl Carousel
+   */
+  var Autoplay = function(carousel) {
+    /**
+     * Reference to the core.
+     * @protected
+     * @type {Owl}
+     */
+    this._core = carousel;
 
     /**
-     * Creates the autoplay plugin.
-     * @class The Autoplay Plugin
-     * @param {Owl} scope - The Owl Carousel
+     * The autoplay interval.
+     * @type {Number}
      */
-    var Autoplay = function (carousel) {
-        /**
-         * Reference to the core.
-         * @protected
-         * @type {Owl}
-         */
-        this._core = carousel;
-
-        /**
-         * The autoplay interval.
-         * @type {Number}
-         */
-        this._interval = null;
-
-        /**
-         * Indicates whenever the autoplay is paused.
-         * @type {Boolean}
-         */
-        this._paused = false;
-
-        /**
-         * All event handlers.
-         * @protected
-         * @type {Object}
-         */
-        this._handlers = {
-            'changed.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && e.property.name === 'settings') {
-                    if (this._core.settings.autoplay) {
-                        this.play();
-                    } else {
-                        this.stop();
-                    }
-                }
-            }, this),
-            'initialized.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._core.settings.autoplay) {
-                    this.play();
-                }
-            }, this),
-            'play.owl.autoplay': $.proxy(function (e, t, s) {
-                if (e.namespace) {
-                    this.play(t, s);
-                }
-            }, this),
-            'stop.owl.autoplay': $.proxy(function (e) {
-                if (e.namespace) {
-                    this.stop();
-                }
-            }, this),
-            'mouseover.owl.autoplay': $.proxy(function () {
-                if (this._core.settings.autoplayHoverPause && this._core.is('rotating')) {
-                    this.pause();
-                }
-            }, this),
-            'mouseleave.owl.autoplay': $.proxy(function () {
-                if (this._core.settings.autoplayHoverPause && this._core.is('rotating')) {
-                    this.play();
-                }
-            }, this)
-        };
-
-        // register event handlers
-        this._core.$element.on(this._handlers);
-
-        // set default options
-        this._core.options = $.extend({}, Autoplay.Defaults, this._core.options);
-    };
+    this._interval = null;
 
     /**
-     * Default options.
-     * @public
+     * Indicates whenever the autoplay is paused.
+     * @type {Boolean}
      */
-    Autoplay.Defaults = {
-        autoplay: true,
-        autoplayTimeout: 5000,
-        autoplayHoverPause: true,
-        autoplaySpeed: false
-    };
+    this._paused = false;
 
     /**
-     * Starts the autoplay.
-     * @public
-     * @param {Number} [timeout] - The interval before the next animation starts.
-     * @param {Number} [speed] - The animation speed for the animations.
+     * All event handlers.
+     * @protected
+     * @type {Object}
      */
-    Autoplay.prototype.play = function (timeout, speed) {
-        this._paused = false;
-
-        if (this._core.is('rotating')) {
-            return;
+    this._handlers = {
+      'changed.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && e.property.name === 'settings') {
+          if (this._core.settings.autoplay) {
+            this.play();
+          } else {
+            this.stop();
+          }
         }
-
-        this._core.enter('rotating');
-
-        this._interval = window.setInterval($.proxy(function () {
-            if (this._paused || this._core.is('busy') || this._core.is('interacting') || document.hidden) {
-                return;
-            }
-            this._core.next(speed || this._core.settings.autoplaySpeed);
-        }, this), timeout || this._core.settings.autoplayTimeout);
+      }, this),
+      'initialized.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._core.settings.autoplay) {
+          this.play();
+        }
+      }, this),
+      'play.owl.autoplay': $.proxy(function(e, t, s) {
+        if (e.namespace) {
+          this.play(t, s);
+        }
+      }, this),
+      'stop.owl.autoplay': $.proxy(function(e) {
+        if (e.namespace) {
+          this.stop();
+        }
+      }, this),
+      'mouseover.owl.autoplay': $.proxy(function() {
+        if (this._core.settings.autoplayHoverPause && this._core.is('rotating')) {
+          this.pause();
+        }
+      }, this),
+      'mouseleave.owl.autoplay': $.proxy(function() {
+        if (this._core.settings.autoplayHoverPause && this._core.is('rotating')) {
+          this.play();
+        }
+      }, this)
     };
 
-    /**
-     * Stops the autoplay.
-     * @public
-     */
-    Autoplay.prototype.stop = function () {
-        if (!this._core.is('rotating')) {
-            return;
-        }
+    // register event handlers
+    this._core.$element.on(this._handlers);
 
-        window.clearInterval(this._interval);
-        this._core.leave('rotating');
-    };
+    // set default options
+    this._core.options = $.extend({}, Autoplay.Defaults, this._core.options);
+  };
 
-    /**
-     * Stops the autoplay.
-     * @public
-     */
-    Autoplay.prototype.pause = function () {
-        if (!this._core.is('rotating')) {
-            return;
-        }
+  /**
+   * Default options.
+   * @public
+   */
+  Autoplay.Defaults = {
+    autoplay: true,
+    autoplayTimeout: 5000,
+    autoplayHoverPause: true,
+    autoplaySpeed: false
+  };
 
-        this._paused = true;
-    };
+  /**
+   * Starts the autoplay.
+   * @public
+   * @param {Number} [timeout] - The interval before the next animation starts.
+   * @param {Number} [speed] - The animation speed for the animations.
+   */
+  Autoplay.prototype.play = function(timeout, speed) {
+    this._paused = false;
 
-    /**
-     * Destroys the plugin.
-     */
-    Autoplay.prototype.destroy = function () {
-        var handler, property;
+    if (this._core.is('rotating')) {
+      return;
+    }
 
-        this.stop();
+    this._core.enter('rotating');
 
-        for (handler in this._handlers) {
-            this._core.$element.off(handler, this._handlers[handler]);
-        }
-        for (property in Object.getOwnPropertyNames(this)) {
-            typeof this[property] != 'function' && (this[property] = null);
-        }
-    };
+    this._interval = window.setInterval($.proxy(function() {
+      if (this._paused || this._core.is('busy') || this._core.is('interacting') || document.hidden) {
+        return;
+      }
+      this._core.next(speed || this._core.settings.autoplaySpeed);
+    }, this), timeout || this._core.settings.autoplayTimeout);
+  };
 
-    $.fn.owlCarousel.Constructor.Plugins.autoplay = Autoplay;
+  /**
+   * Stops the autoplay.
+   * @public
+   */
+  Autoplay.prototype.stop = function() {
+    if (!this._core.is('rotating')) {
+      return;
+    }
+
+    window.clearInterval(this._interval);
+    this._core.leave('rotating');
+  };
+
+  /**
+   * Stops the autoplay.
+   * @public
+   */
+  Autoplay.prototype.pause = function() {
+    if (!this._core.is('rotating')) {
+      return;
+    }
+
+    this._paused = true;
+  };
+
+  /**
+   * Destroys the plugin.
+   */
+  Autoplay.prototype.destroy = function() {
+    var handler, property;
+
+    this.stop();
+
+    for (handler in this._handlers) {
+      this._core.$element.off(handler, this._handlers[handler]);
+    }
+    for (property in Object.getOwnPropertyNames(this)) {
+      typeof this[property] != 'function' && (this[property] = null);
+    }
+  };
+
+  $.fn.owlCarousel.Constructor.Plugins.autoplay = Autoplay;
 
 })(window.Zepto || window.jQuery, window, document);
 
@@ -4566,379 +4566,379 @@ var fakewaffle = (function ($, fakewaffle) {
  * @author Artus Kolanowski
  * @license The MIT License (MIT)
  */
-; (function ($, window, document, undefined) {
-    'use strict';
+;(function($, window, document, undefined) {
+  'use strict';
 
+  /**
+   * Creates the navigation plugin.
+   * @class The Navigation Plugin
+   * @param {Owl} carousel - The Owl Carousel.
+   */
+  var Navigation = function(carousel) {
     /**
-     * Creates the navigation plugin.
-     * @class The Navigation Plugin
-     * @param {Owl} carousel - The Owl Carousel.
-     */
-    var Navigation = function (carousel) {
-        /**
-         * Reference to the core.
-         * @protected
-         * @type {Owl}
-         */
-        this._core = carousel;
-
-        /**
-         * Indicates whether the plugin is initialized or not.
-         * @protected
-         * @type {Boolean}
-         */
-        this._initialized = false;
-
-        /**
-         * The current paging indexes.
-         * @protected
-         * @type {Array}
-         */
-        this._pages = [];
-
-        /**
-         * All DOM elements of the user interface.
-         * @protected
-         * @type {Object}
-         */
-        this._controls = {};
-
-        /**
-         * Markup for an indicator.
-         * @protected
-         * @type {Array.<String>}
-         */
-        this._templates = [];
-
-        /**
-         * The carousel element.
-         * @type {jQuery}
-         */
-        this.$element = this._core.$element;
-
-        /**
-         * Overridden methods of the carousel.
-         * @protected
-         * @type {Object}
-         */
-        this._overrides = {
-            next: this._core.next,
-            prev: this._core.prev,
-            to: this._core.to
-        };
-
-        /**
-         * All event handlers.
-         * @protected
-         * @type {Object}
-         */
-        this._handlers = {
-            'prepared.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._core.settings.dotsData) {
-                    this._templates.push('<div class="' + this._core.settings.dotClass + '">' +
-                      $(e.content).find('[data-dot]').andSelf('[data-dot]').attr('data-dot') + '</div>');
-                }
-            }, this),
-            'added.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._core.settings.dotsData) {
-                    this._templates.splice(e.position, 0, this._templates.pop());
-                }
-            }, this),
-            'remove.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._core.settings.dotsData) {
-                    this._templates.splice(e.position, 1);
-                }
-            }, this),
-            'changed.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && e.property.name == 'position') {
-                    this.draw();
-                }
-            }, this),
-            'initialized.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && !this._initialized) {
-                    this._core.trigger('initialize', null, 'navigation');
-                    this.initialize();
-                    this.update();
-                    this.draw();
-                    this._initialized = true;
-                    this._core.trigger('initialized', null, 'navigation');
-                }
-            }, this),
-            'refreshed.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._initialized) {
-                    this._core.trigger('refresh', null, 'navigation');
-                    this.update();
-                    this.draw();
-                    this._core.trigger('refreshed', null, 'navigation');
-                }
-            }, this)
-        };
-
-        // set default options
-        this._core.options = $.extend({}, Navigation.Defaults, this._core.options);
-
-        // register event handlers
-        this.$element.on(this._handlers);
-    };
-
-    /**
-     * Default options.
-     * @public
-     * @todo Rename `slideBy` to `navBy`
-     */
-    Navigation.Defaults = {
-        nav: false,
-        navText: ['prev', 'next'],
-        navSpeed: false,
-        navElement: 'div',
-        navContainer: false,
-        navContainerClass: 'owl-nav',
-        navClass: ['owl-prev', 'owl-next'],
-        slideBy: 1,
-        dotClass: 'owl-dot',
-        dotsClass: 'owl-dots',
-        dots: true,
-        dotsEach: false,
-        dotsData: false,
-        dotsSpeed: false,
-        dotsContainer: false
-    };
-
-    /**
-     * Initializes the layout of the plugin and extends the carousel.
+     * Reference to the core.
      * @protected
+     * @type {Owl}
      */
-    Navigation.prototype.initialize = function () {
-        var override,
-          settings = this._core.settings;
-
-        // create DOM structure for relative navigation
-        this._controls.$relative = (settings.navContainer ? $(settings.navContainer)
-          : $('<div>').addClass(settings.navContainerClass).appendTo(this.$element)).addClass('disabled');
-
-        this._controls.$previous = $('<' + settings.navElement + '>')
-          .addClass(settings.navClass[0])
-          .html(settings.navText[0])
-          .prependTo(this._controls.$relative)
-          .on('click', $.proxy(function (e) {
-              this.prev(settings.navSpeed);
-          }, this));
-        this._controls.$next = $('<' + settings.navElement + '>')
-          .addClass(settings.navClass[1])
-          .html(settings.navText[1])
-          .appendTo(this._controls.$relative)
-          .on('click', $.proxy(function (e) {
-              this.next(settings.navSpeed);
-          }, this));
-
-        // create DOM structure for absolute navigation
-        if (!settings.dotsData) {
-            this._templates = [$('<div>')
-              .addClass(settings.dotClass)
-              .append($('<span>'))
-              .prop('outerHTML')];
-        }
-
-        this._controls.$absolute = (settings.dotsContainer ? $(settings.dotsContainer)
-          : $('<div>').addClass(settings.dotsClass).appendTo(this.$element)).addClass('disabled');
-
-        this._controls.$absolute.on('click', 'div', $.proxy(function (e) {
-            var index = $(e.target).parent().is(this._controls.$absolute)
-              ? $(e.target).index() : $(e.target).parent().index();
-
-            e.preventDefault();
-
-            this.to(index, settings.dotsSpeed);
-        }, this));
-
-        // override public methods of the carousel
-        for (override in this._overrides) {
-            this._core[override] = $.proxy(this[override], this);
-        }
-    };
+    this._core = carousel;
 
     /**
-     * Destroys the plugin.
+     * Indicates whether the plugin is initialized or not.
      * @protected
+     * @type {Boolean}
      */
-    Navigation.prototype.destroy = function () {
-        var handler, control, property, override;
-
-        for (handler in this._handlers) {
-            this.$element.off(handler, this._handlers[handler]);
-        }
-        for (control in this._controls) {
-            this._controls[control].remove();
-        }
-        for (override in this.overides) {
-            this._core[override] = this._overrides[override];
-        }
-        for (property in Object.getOwnPropertyNames(this)) {
-            typeof this[property] != 'function' && (this[property] = null);
-        }
-    };
+    this._initialized = false;
 
     /**
-     * Updates the internal state.
+     * The current paging indexes.
      * @protected
+     * @type {Array}
      */
-    Navigation.prototype.update = function () {
-        var i, j, k,
-          lower = this._core.clones().length / 2,
-          upper = lower + this._core.items().length,
-          maximum = this._core.maximum(true),
-          settings = this._core.settings,
-          size = settings.center || settings.autoWidth || settings.dotsData
-            ? 1 : settings.dotsEach || settings.items;
-
-        if (settings.slideBy !== 'page') {
-            settings.slideBy = Math.min(settings.slideBy, settings.items);
-        }
-
-        if (settings.dots || settings.slideBy == 'page') {
-            this._pages = [];
-
-            for (i = lower, j = 0, k = 0; i < upper; i++) {
-                if (j >= size || j === 0) {
-                    this._pages.push({
-                        start: Math.min(maximum, i - lower),
-                        end: i - lower + size - 1
-                    });
-                    if (Math.min(maximum, i - lower) === maximum) {
-                        break;
-                    }
-                    j = 0, ++k;
-                }
-                j += this._core.mergers(this._core.relative(i));
-            }
-        }
-    };
+    this._pages = [];
 
     /**
-     * Draws the user interface.
-     * @todo The option `dotsData` wont work.
+     * All DOM elements of the user interface.
      * @protected
+     * @type {Object}
      */
-    Navigation.prototype.draw = function () {
-        var difference,
-          settings = this._core.settings,
-          disabled = this._core.items().length <= settings.items,
-          index = this._core.relative(this._core.current()),
-          loop = settings.loop || settings.rewind;
-
-        this._controls.$relative.toggleClass('disabled', !settings.nav || disabled);
-
-        if (settings.nav) {
-            this._controls.$previous.toggleClass('disabled', !loop && index <= this._core.minimum(true));
-            this._controls.$next.toggleClass('disabled', !loop && index >= this._core.maximum(true));
-        }
-
-        this._controls.$absolute.toggleClass('disabled', !settings.dots || disabled);
-
-        if (settings.dots) {
-            difference = this._pages.length - this._controls.$absolute.children().length;
-
-            if (settings.dotsData && difference !== 0) {
-                this._controls.$absolute.html(this._templates.join(''));
-            } else if (difference > 0) {
-                this._controls.$absolute.append(new Array(difference + 1).join(this._templates[0]));
-            } else if (difference < 0) {
-                this._controls.$absolute.children().slice(difference).remove();
-            }
-
-            this._controls.$absolute.find('.active').removeClass('active');
-            this._controls.$absolute.children().eq($.inArray(this.current(), this._pages)).addClass('active');
-        }
-    };
+    this._controls = {};
 
     /**
-     * Extends event data.
+     * Markup for an indicator.
      * @protected
-     * @param {Event} event - The event object which gets thrown.
+     * @type {Array.<String>}
      */
-    Navigation.prototype.onTrigger = function (event) {
-        var settings = this._core.settings;
-
-        event.page = {
-            index: $.inArray(this.current(), this._pages),
-            count: this._pages.length,
-            size: settings && (settings.center || settings.autoWidth || settings.dotsData
-              ? 1 : settings.dotsEach || settings.items)
-        };
-    };
+    this._templates = [];
 
     /**
-     * Gets the current page position of the carousel.
+     * The carousel element.
+     * @type {jQuery}
+     */
+    this.$element = this._core.$element;
+
+    /**
+     * Overridden methods of the carousel.
      * @protected
-     * @returns {Number}
+     * @type {Object}
      */
-    Navigation.prototype.current = function () {
-        var current = this._core.relative(this._core.current());
-        return $.grep(this._pages, $.proxy(function (page, index) {
-            return page.start <= current && page.end >= current;
-        }, this)).pop();
+    this._overrides = {
+      next: this._core.next,
+      prev: this._core.prev,
+      to: this._core.to
     };
 
     /**
-     * Gets the current succesor/predecessor position.
+     * All event handlers.
      * @protected
-     * @returns {Number}
+     * @type {Object}
      */
-    Navigation.prototype.getPosition = function (successor) {
-        var position, length,
-          settings = this._core.settings;
-
-        if (settings.slideBy == 'page') {
-            position = $.inArray(this.current(), this._pages);
-            length = this._pages.length;
-            successor ? ++position : --position;
-            position = this._pages[((position % length) + length) % length].start;
-        } else {
-            position = this._core.relative(this._core.current());
-            length = this._core.items().length;
-            successor ? position += settings.slideBy : position -= settings.slideBy;
+    this._handlers = {
+      'prepared.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._core.settings.dotsData) {
+          this._templates.push('<div class="' + this._core.settings.dotClass + '">' +
+            $(e.content).find('[data-dot]').andSelf('[data-dot]').attr('data-dot') + '</div>');
         }
-
-        return position;
-    };
-
-    /**
-     * Slides to the next item or page.
-     * @public
-     * @param {Number} [speed=false] - The time in milliseconds for the transition.
-     */
-    Navigation.prototype.next = function (speed) {
-        $.proxy(this._overrides.to, this._core)(this.getPosition(true), speed);
-    };
-
-    /**
-     * Slides to the previous item or page.
-     * @public
-     * @param {Number} [speed=false] - The time in milliseconds for the transition.
-     */
-    Navigation.prototype.prev = function (speed) {
-        $.proxy(this._overrides.to, this._core)(this.getPosition(false), speed);
-    };
-
-    /**
-     * Slides to the specified item or page.
-     * @public
-     * @param {Number} position - The position of the item or page.
-     * @param {Number} [speed] - The time in milliseconds for the transition.
-     * @param {Boolean} [standard=false] - Whether to use the standard behaviour or not.
-     */
-    Navigation.prototype.to = function (position, speed, standard) {
-        var length;
-
-        if (!standard) {
-            length = this._pages.length;
-            $.proxy(this._overrides.to, this._core)(this._pages[((position % length) + length) % length].start, speed);
-        } else {
-            $.proxy(this._overrides.to, this._core)(position, speed);
+      }, this),
+      'added.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._core.settings.dotsData) {
+          this._templates.splice(e.position, 0, this._templates.pop());
         }
+      }, this),
+      'remove.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._core.settings.dotsData) {
+          this._templates.splice(e.position, 1);
+        }
+      }, this),
+      'changed.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && e.property.name == 'position') {
+          this.draw();
+        }
+      }, this),
+      'initialized.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && !this._initialized) {
+          this._core.trigger('initialize', null, 'navigation');
+          this.initialize();
+          this.update();
+          this.draw();
+          this._initialized = true;
+          this._core.trigger('initialized', null, 'navigation');
+        }
+      }, this),
+      'refreshed.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._initialized) {
+          this._core.trigger('refresh', null, 'navigation');
+          this.update();
+          this.draw();
+          this._core.trigger('refreshed', null, 'navigation');
+        }
+      }, this)
     };
 
-    $.fn.owlCarousel.Constructor.Plugins.Navigation = Navigation;
+    // set default options
+    this._core.options = $.extend({}, Navigation.Defaults, this._core.options);
+
+    // register event handlers
+    this.$element.on(this._handlers);
+  };
+
+  /**
+   * Default options.
+   * @public
+   * @todo Rename `slideBy` to `navBy`
+   */
+  Navigation.Defaults = {
+    nav: false,
+    navText: [ 'prev', 'next' ],
+    navSpeed: false,
+    navElement: 'div',
+    navContainer: false,
+    navContainerClass: 'owl-nav',
+    navClass: [ 'owl-prev', 'owl-next' ],
+    slideBy: 1,
+    dotClass: 'owl-dot',
+    dotsClass: 'owl-dots',
+    dots: true,
+    dotsEach: false,
+    dotsData: false,
+    dotsSpeed: false,
+    dotsContainer: false
+  };
+
+  /**
+   * Initializes the layout of the plugin and extends the carousel.
+   * @protected
+   */
+  Navigation.prototype.initialize = function() {
+    var override,
+      settings = this._core.settings;
+
+    // create DOM structure for relative navigation
+    this._controls.$relative = (settings.navContainer ? $(settings.navContainer)
+      : $('<div>').addClass(settings.navContainerClass).appendTo(this.$element)).addClass('disabled');
+
+    this._controls.$previous = $('<' + settings.navElement + '>')
+      .addClass(settings.navClass[0])
+      .html(settings.navText[0])
+      .prependTo(this._controls.$relative)
+      .on('click', $.proxy(function(e) {
+        this.prev(settings.navSpeed);
+      }, this));
+    this._controls.$next = $('<' + settings.navElement + '>')
+      .addClass(settings.navClass[1])
+      .html(settings.navText[1])
+      .appendTo(this._controls.$relative)
+      .on('click', $.proxy(function(e) {
+        this.next(settings.navSpeed);
+      }, this));
+
+    // create DOM structure for absolute navigation
+    if (!settings.dotsData) {
+      this._templates = [ $('<div>')
+        .addClass(settings.dotClass)
+        .append($('<span>'))
+        .prop('outerHTML') ];
+    }
+
+    this._controls.$absolute = (settings.dotsContainer ? $(settings.dotsContainer)
+      : $('<div>').addClass(settings.dotsClass).appendTo(this.$element)).addClass('disabled');
+
+    this._controls.$absolute.on('click', 'div', $.proxy(function(e) {
+      var index = $(e.target).parent().is(this._controls.$absolute)
+        ? $(e.target).index() : $(e.target).parent().index();
+
+      e.preventDefault();
+
+      this.to(index, settings.dotsSpeed);
+    }, this));
+
+    // override public methods of the carousel
+    for (override in this._overrides) {
+      this._core[override] = $.proxy(this[override], this);
+    }
+  };
+
+  /**
+   * Destroys the plugin.
+   * @protected
+   */
+  Navigation.prototype.destroy = function() {
+    var handler, control, property, override;
+
+    for (handler in this._handlers) {
+      this.$element.off(handler, this._handlers[handler]);
+    }
+    for (control in this._controls) {
+      this._controls[control].remove();
+    }
+    for (override in this.overides) {
+      this._core[override] = this._overrides[override];
+    }
+    for (property in Object.getOwnPropertyNames(this)) {
+      typeof this[property] != 'function' && (this[property] = null);
+    }
+  };
+
+  /**
+   * Updates the internal state.
+   * @protected
+   */
+  Navigation.prototype.update = function() {
+    var i, j, k,
+      lower = this._core.clones().length / 2,
+      upper = lower + this._core.items().length,
+      maximum = this._core.maximum(true),
+      settings = this._core.settings,
+      size = settings.center || settings.autoWidth || settings.dotsData
+        ? 1 : settings.dotsEach || settings.items;
+
+    if (settings.slideBy !== 'page') {
+      settings.slideBy = Math.min(settings.slideBy, settings.items);
+    }
+
+    if (settings.dots || settings.slideBy == 'page') {
+      this._pages = [];
+
+      for (i = lower, j = 0, k = 0; i < upper; i++) {
+        if (j >= size || j === 0) {
+          this._pages.push({
+            start: Math.min(maximum, i - lower),
+            end: i - lower + size - 1
+          });
+          if (Math.min(maximum, i - lower) === maximum) {
+            break;
+          }
+          j = 0, ++k;
+        }
+        j += this._core.mergers(this._core.relative(i));
+      }
+    }
+  };
+
+  /**
+   * Draws the user interface.
+   * @todo The option `dotsData` wont work.
+   * @protected
+   */
+  Navigation.prototype.draw = function() {
+    var difference,
+      settings = this._core.settings,
+      disabled = this._core.items().length <= settings.items,
+      index = this._core.relative(this._core.current()),
+      loop = settings.loop || settings.rewind;
+
+    this._controls.$relative.toggleClass('disabled', !settings.nav || disabled);
+
+    if (settings.nav) {
+      this._controls.$previous.toggleClass('disabled', !loop && index <= this._core.minimum(true));
+      this._controls.$next.toggleClass('disabled', !loop && index >= this._core.maximum(true));
+    }
+
+    this._controls.$absolute.toggleClass('disabled', !settings.dots || disabled);
+
+    if (settings.dots) {
+      difference = this._pages.length - this._controls.$absolute.children().length;
+
+      if (settings.dotsData && difference !== 0) {
+        this._controls.$absolute.html(this._templates.join(''));
+      } else if (difference > 0) {
+        this._controls.$absolute.append(new Array(difference + 1).join(this._templates[0]));
+      } else if (difference < 0) {
+        this._controls.$absolute.children().slice(difference).remove();
+      }
+
+      this._controls.$absolute.find('.active').removeClass('active');
+      this._controls.$absolute.children().eq($.inArray(this.current(), this._pages)).addClass('active');
+    }
+  };
+
+  /**
+   * Extends event data.
+   * @protected
+   * @param {Event} event - The event object which gets thrown.
+   */
+  Navigation.prototype.onTrigger = function(event) {
+    var settings = this._core.settings;
+
+    event.page = {
+      index: $.inArray(this.current(), this._pages),
+      count: this._pages.length,
+      size: settings && (settings.center || settings.autoWidth || settings.dotsData
+        ? 1 : settings.dotsEach || settings.items)
+    };
+  };
+
+  /**
+   * Gets the current page position of the carousel.
+   * @protected
+   * @returns {Number}
+   */
+  Navigation.prototype.current = function() {
+    var current = this._core.relative(this._core.current());
+    return $.grep(this._pages, $.proxy(function(page, index) {
+      return page.start <= current && page.end >= current;
+    }, this)).pop();
+  };
+
+  /**
+   * Gets the current succesor/predecessor position.
+   * @protected
+   * @returns {Number}
+   */
+  Navigation.prototype.getPosition = function(successor) {
+    var position, length,
+      settings = this._core.settings;
+
+    if (settings.slideBy == 'page') {
+      position = $.inArray(this.current(), this._pages);
+      length = this._pages.length;
+      successor ? ++position : --position;
+      position = this._pages[((position % length) + length) % length].start;
+    } else {
+      position = this._core.relative(this._core.current());
+      length = this._core.items().length;
+      successor ? position += settings.slideBy : position -= settings.slideBy;
+    }
+
+    return position;
+  };
+
+  /**
+   * Slides to the next item or page.
+   * @public
+   * @param {Number} [speed=false] - The time in milliseconds for the transition.
+   */
+  Navigation.prototype.next = function(speed) {
+    $.proxy(this._overrides.to, this._core)(this.getPosition(true), speed);
+  };
+
+  /**
+   * Slides to the previous item or page.
+   * @public
+   * @param {Number} [speed=false] - The time in milliseconds for the transition.
+   */
+  Navigation.prototype.prev = function(speed) {
+    $.proxy(this._overrides.to, this._core)(this.getPosition(false), speed);
+  };
+
+  /**
+   * Slides to the specified item or page.
+   * @public
+   * @param {Number} position - The position of the item or page.
+   * @param {Number} [speed] - The time in milliseconds for the transition.
+   * @param {Boolean} [standard=false] - Whether to use the standard behaviour or not.
+   */
+  Navigation.prototype.to = function(position, speed, standard) {
+    var length;
+
+    if (!standard) {
+      length = this._pages.length;
+      $.proxy(this._overrides.to, this._core)(this._pages[((position % length) + length) % length].start, speed);
+    } else {
+      $.proxy(this._overrides.to, this._core)(position, speed);
+    }
+  };
+
+  $.fn.owlCarousel.Constructor.Plugins.Navigation = Navigation;
 
 })(window.Zepto || window.jQuery, window, document);
 
@@ -4948,119 +4948,119 @@ var fakewaffle = (function ($, fakewaffle) {
  * @author Artus Kolanowski
  * @license The MIT License (MIT)
  */
-; (function ($, window, document, undefined) {
-    'use strict';
+;(function($, window, document, undefined) {
+  'use strict';
+
+  /**
+   * Creates the hash plugin.
+   * @class The Hash Plugin
+   * @param {Owl} carousel - The Owl Carousel
+   */
+  var Hash = function(carousel) {
+    /**
+     * Reference to the core.
+     * @protected
+     * @type {Owl}
+     */
+    this._core = carousel;
 
     /**
-     * Creates the hash plugin.
-     * @class The Hash Plugin
-     * @param {Owl} carousel - The Owl Carousel
+     * Hash index for the items.
+     * @protected
+     * @type {Object}
      */
-    var Hash = function (carousel) {
-        /**
-         * Reference to the core.
-         * @protected
-         * @type {Owl}
-         */
-        this._core = carousel;
-
-        /**
-         * Hash index for the items.
-         * @protected
-         * @type {Object}
-         */
-        this._hashes = {};
-
-        /**
-         * The carousel element.
-         * @type {jQuery}
-         */
-        this.$element = this._core.$element;
-
-        /**
-         * All event handlers.
-         * @protected
-         * @type {Object}
-         */
-        this._handlers = {
-            'initialized.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && this._core.settings.startPosition === 'URLHash') {
-                    $(window).trigger('hashchange.owl.navigation');
-                }
-            }, this),
-            'prepared.owl.carousel': $.proxy(function (e) {
-                if (e.namespace) {
-                    var hash = $(e.content).find('[data-hash]').andSelf('[data-hash]').attr('data-hash');
-
-                    if (!hash) {
-                        return;
-                    }
-
-                    this._hashes[hash] = e.content;
-                }
-            }, this),
-            'changed.owl.carousel': $.proxy(function (e) {
-                if (e.namespace && e.property.name === 'position') {
-                    var current = this._core.items(this._core.relative(this._core.current())),
-                      hash = $.map(this._hashes, function (item, hash) {
-                          return item === current ? hash : null;
-                      }).join();
-
-                    if (!hash || window.location.hash.slice(1) === hash) {
-                        return;
-                    }
-
-                    window.location.hash = hash;
-                }
-            }, this)
-        };
-
-        // set default options
-        this._core.options = $.extend({}, Hash.Defaults, this._core.options);
-
-        // register the event handlers
-        this.$element.on(this._handlers);
-
-        // register event listener for hash navigation
-        $(window).on('hashchange.owl.navigation', $.proxy(function (e) {
-            var hash = window.location.hash.substring(1),
-              items = this._core.$stage.children(),
-              position = this._hashes[hash] && items.index(this._hashes[hash]);
-
-            if (position === undefined || position === this._core.current()) {
-                return;
-            }
-
-            this._core.to(this._core.relative(position), false, true);
-        }, this));
-    };
+    this._hashes = {};
 
     /**
-     * Default options.
-     * @public
+     * The carousel element.
+     * @type {jQuery}
      */
-    Hash.Defaults = {
-        URLhashListener: false
-    };
+    this.$element = this._core.$element;
 
     /**
-     * Destroys the plugin.
-     * @public
+     * All event handlers.
+     * @protected
+     * @type {Object}
      */
-    Hash.prototype.destroy = function () {
-        var handler, property;
-
-        $(window).off('hashchange.owl.navigation');
-
-        for (handler in this._handlers) {
-            this._core.$element.off(handler, this._handlers[handler]);
+    this._handlers = {
+      'initialized.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && this._core.settings.startPosition === 'URLHash') {
+          $(window).trigger('hashchange.owl.navigation');
         }
-        for (property in Object.getOwnPropertyNames(this)) {
-            typeof this[property] != 'function' && (this[property] = null);
+      }, this),
+      'prepared.owl.carousel': $.proxy(function(e) {
+        if (e.namespace) {
+          var hash = $(e.content).find('[data-hash]').andSelf('[data-hash]').attr('data-hash');
+
+          if (!hash) {
+            return;
+          }
+
+          this._hashes[hash] = e.content;
         }
+      }, this),
+      'changed.owl.carousel': $.proxy(function(e) {
+        if (e.namespace && e.property.name === 'position') {
+          var current = this._core.items(this._core.relative(this._core.current())),
+            hash = $.map(this._hashes, function(item, hash) {
+              return item === current ? hash : null;
+            }).join();
+
+          if (!hash || window.location.hash.slice(1) === hash) {
+            return;
+          }
+
+          window.location.hash = hash;
+        }
+      }, this)
     };
 
-    $.fn.owlCarousel.Constructor.Plugins.Hash = Hash;
+    // set default options
+    this._core.options = $.extend({}, Hash.Defaults, this._core.options);
+
+    // register the event handlers
+    this.$element.on(this._handlers);
+
+    // register event listener for hash navigation
+    $(window).on('hashchange.owl.navigation', $.proxy(function(e) {
+      var hash = window.location.hash.substring(1),
+        items = this._core.$stage.children(),
+        position = this._hashes[hash] && items.index(this._hashes[hash]);
+
+      if (position === undefined || position === this._core.current()) {
+        return;
+      }
+
+      this._core.to(this._core.relative(position), false, true);
+    }, this));
+  };
+
+  /**
+   * Default options.
+   * @public
+   */
+  Hash.Defaults = {
+    URLhashListener: false
+  };
+
+  /**
+   * Destroys the plugin.
+   * @public
+   */
+  Hash.prototype.destroy = function() {
+    var handler, property;
+
+    $(window).off('hashchange.owl.navigation');
+
+    for (handler in this._handlers) {
+      this._core.$element.off(handler, this._handlers[handler]);
+    }
+    for (property in Object.getOwnPropertyNames(this)) {
+      typeof this[property] != 'function' && (this[property] = null);
+    }
+  };
+
+  $.fn.owlCarousel.Constructor.Plugins.Hash = Hash;
 
 })(window.Zepto || window.jQuery, window, document);
 
@@ -5072,78 +5072,78 @@ var fakewaffle = (function ($, fakewaffle) {
  * @author Artus Kolanowski
  * @license The MIT License (MIT)
  */
-; (function ($, window, document, undefined) {
+;(function($, window, document, undefined) {
 
-    var style = $('<support>').get(0).style,
-      prefixes = 'Webkit Moz O ms'.split(' '),
-      events = {
-          transition: {
-              end: {
-                  WebkitTransition: 'webkitTransitionEnd',
-                  MozTransition: 'transitionend',
-                  OTransition: 'oTransitionEnd',
-                  transition: 'transitionend'
-              }
-          },
-          animation: {
-              end: {
-                  WebkitAnimation: 'webkitAnimationEnd',
-                  MozAnimation: 'animationend',
-                  OAnimation: 'oAnimationEnd',
-                  animation: 'animationend'
-              }
-          }
+  var style = $('<support>').get(0).style,
+    prefixes = 'Webkit Moz O ms'.split(' '),
+    events = {
+      transition: {
+        end: {
+          WebkitTransition: 'webkitTransitionEnd',
+          MozTransition: 'transitionend',
+          OTransition: 'oTransitionEnd',
+          transition: 'transitionend'
+        }
       },
-      tests = {
-          csstransforms: function () {
-              return !!test('transform');
-          },
-          csstransforms3d: function () {
-              return !!test('perspective');
-          },
-          csstransitions: function () {
-              return !!test('transition');
-          },
-          cssanimations: function () {
-              return !!test('animation');
-          }
-      };
+      animation: {
+        end: {
+          WebkitAnimation: 'webkitAnimationEnd',
+          MozAnimation: 'animationend',
+          OAnimation: 'oAnimationEnd',
+          animation: 'animationend'
+        }
+      }
+    },
+    tests = {
+      csstransforms: function() {
+        return !!test('transform');
+      },
+      csstransforms3d: function() {
+        return !!test('perspective');
+      },
+      csstransitions: function() {
+        return !!test('transition');
+      },
+      cssanimations: function() {
+        return !!test('animation');
+      }
+    };
 
-    function test(property, prefixed) {
-        var result = false,
-          upper = property.charAt(0).toUpperCase() + property.slice(1);
+  function test(property, prefixed) {
+    var result = false,
+      upper = property.charAt(0).toUpperCase() + property.slice(1);
 
-        $.each((property + ' ' + prefixes.join(upper + ' ') + upper).split(' '), function (i, property) {
-            if (style[property] !== undefined) {
-                result = prefixed ? property : true;
-                return false;
-            }
-        });
+    $.each((property + ' ' + prefixes.join(upper + ' ') + upper).split(' '), function(i, property) {
+      if (style[property] !== undefined) {
+        result = prefixed ? property : true;
+        return false;
+      }
+    });
 
-        return result;
-    }
+    return result;
+  }
 
-    function prefixed(property) {
-        return test(property, true);
-    }
+  function prefixed(property) {
+    return test(property, true);
+  }
 
-    if (tests.csstransitions()) {
-        /* jshint -W053 */
-        $.support.transition = new String(prefixed('transition'))
-        $.support.transition.end = events.transition.end[$.support.transition];
-    }
+  if (tests.csstransitions()) {
+    /* jshint -W053 */
+    $.support.transition = new String(prefixed('transition'))
+    $.support.transition.end = events.transition.end[ $.support.transition ];
+  }
 
-    if (tests.cssanimations()) {
-        /* jshint -W053 */
-        $.support.animation = new String(prefixed('animation'))
-        $.support.animation.end = events.animation.end[$.support.animation];
-    }
+  if (tests.cssanimations()) {
+    /* jshint -W053 */
+    $.support.animation = new String(prefixed('animation'))
+    $.support.animation.end = events.animation.end[ $.support.animation ];
+  }
 
-    if (tests.csstransforms()) {
-        /* jshint -W053 */
-        $.support.transform = new String(prefixed('transform'));
-        $.support.transform3d = tests.csstransforms3d();
-    }
+  if (tests.csstransforms()) {
+    /* jshint -W053 */
+    $.support.transform = new String(prefixed('transform'));
+    $.support.transform3d = tests.csstransforms3d();
+  }
 
 })(window.Zepto || window.jQuery, window, document);
 
@@ -5159,241 +5159,241 @@ var fakewaffle = (function ($, fakewaffle) {
  *
  */
 
-; (function (window, document, $, undefined) {
-    "use strict";
+;(function (window, document, $, undefined) {
+	"use strict";
 
-    var H = $("html"),
+	var H = $("html"),
 		W = $(window),
 		D = $(document),
 		F = $.fancybox = function () {
-		    F.open.apply(this, arguments);
+			F.open.apply( this, arguments );
 		},
-		IE = navigator.userAgent.match(/msie/i),
-		didUpdate = null,
-		isTouch = document.createTouch !== undefined,
+		IE =  navigator.userAgent.match(/msie/i),
+		didUpdate	= null,
+		isTouch		= document.createTouch !== undefined,
 
-		isQuery = function (obj) {
-		    return obj && obj.hasOwnProperty && obj instanceof $;
+		isQuery	= function(obj) {
+			return obj && obj.hasOwnProperty && obj instanceof $;
 		},
-		isString = function (str) {
-		    return str && $.type(str) === "string";
+		isString = function(str) {
+			return str && $.type(str) === "string";
 		},
-		isPercentage = function (str) {
-		    return isString(str) && str.indexOf('%') > 0;
+		isPercentage = function(str) {
+			return isString(str) && str.indexOf('%') > 0;
 		},
-		isScrollable = function (el) {
-		    return (el && !(el.style.overflow && el.style.overflow === 'hidden') && ((el.clientWidth && el.scrollWidth > el.clientWidth) || (el.clientHeight && el.scrollHeight > el.clientHeight)));
+		isScrollable = function(el) {
+			return (el && !(el.style.overflow && el.style.overflow === 'hidden') && ((el.clientWidth && el.scrollWidth > el.clientWidth) || (el.clientHeight && el.scrollHeight > el.clientHeight)));
 		},
-		getScalar = function (orig, dim) {
-		    var value = parseInt(orig, 10) || 0;
+		getScalar = function(orig, dim) {
+			var value = parseInt(orig, 10) || 0;
 
-		    if (dim && isPercentage(orig)) {
-		        value = F.getViewport()[dim] / 100 * value;
-		    }
+			if (dim && isPercentage(orig)) {
+				value = F.getViewport()[ dim ] / 100 * value;
+			}
 
-		    return Math.ceil(value);
+			return Math.ceil(value);
 		},
-		getValue = function (value, dim) {
-		    return getScalar(value, dim) + 'px';
+		getValue = function(value, dim) {
+			return getScalar(value, dim) + 'px';
 		};
 
-    $.extend(F, {
-        // The current version of fancyBox
-        version: '2.1.5',
+	$.extend(F, {
+		// The current version of fancyBox
+		version: '2.1.5',
 
-        defaults: {
-            padding: 15,
-            margin: 20,
+		defaults: {
+			padding : 15,
+			margin  : 20,
 
-            width: 800,
-            height: 600,
-            minWidth: 100,
-            minHeight: 100,
-            maxWidth: 9999,
-            maxHeight: 9999,
-            pixelRatio: 1, // Set to 2 for retina display support
+			width     : 800,
+			height    : 600,
+			minWidth  : 100,
+			minHeight : 100,
+			maxWidth  : 9999,
+			maxHeight : 9999,
+			pixelRatio: 1, // Set to 2 for retina display support
 
-            autoSize: true,
-            autoHeight: false,
-            autoWidth: false,
+			autoSize   : true,
+			autoHeight : false,
+			autoWidth  : false,
 
-            autoResize: true,
-            autoCenter: !isTouch,
-            fitToView: true,
-            aspectRatio: false,
-            topRatio: 0.5,
-            leftRatio: 0.5,
+			autoResize  : true,
+			autoCenter  : !isTouch,
+			fitToView   : true,
+			aspectRatio : false,
+			topRatio    : 0.5,
+			leftRatio   : 0.5,
 
-            scrolling: 'auto', // 'auto', 'yes' or 'no'
-            wrapCSS: '',
+			scrolling : 'auto', // 'auto', 'yes' or 'no'
+			wrapCSS   : '',
 
-            arrows: true,
-            closeBtn: true,
-            closeClick: false,
-            nextClick: false,
-            mouseWheel: true,
-            autoPlay: false,
-            playSpeed: 3000,
-            preload: 3,
-            modal: false,
-            loop: true,
+			arrows     : true,
+			closeBtn   : true,
+			closeClick : false,
+			nextClick  : false,
+			mouseWheel : true,
+			autoPlay   : false,
+			playSpeed  : 3000,
+			preload    : 3,
+			modal      : false,
+			loop       : true,
 
-            ajax: {
-                dataType: 'html',
-                headers: { 'X-fancyBox': true }
-            },
-            iframe: {
-                scrolling: 'auto',
-                preload: true
-            },
-            swf: {
-                wmode: 'transparent',
-                allowfullscreen: 'true',
-                allowscriptaccess: 'always'
-            },
+			ajax  : {
+				dataType : 'html',
+				headers  : { 'X-fancyBox': true }
+			},
+			iframe : {
+				scrolling : 'auto',
+				preload   : true
+			},
+			swf : {
+				wmode: 'transparent',
+				allowfullscreen   : 'true',
+				allowscriptaccess : 'always'
+			},
 
-            keys: {
-                next: {
-                    13: 'left', // enter
-                    34: 'up',   // page down
-                    39: 'left', // right arrow
-                    40: 'up'    // down arrow
-                },
-                prev: {
-                    8: 'right',  // backspace
-                    33: 'down',   // page up
-                    37: 'right',  // left arrow
-                    38: 'down'    // up arrow
-                },
-                close: [27], // escape key
-                play: [32], // space - start/stop slideshow
-                toggle: [70]  // letter "f" - toggle fullscreen
-            },
+			keys  : {
+				next : {
+					13 : 'left', // enter
+					34 : 'up',   // page down
+					39 : 'left', // right arrow
+					40 : 'up'    // down arrow
+				},
+				prev : {
+					8  : 'right',  // backspace
+					33 : 'down',   // page up
+					37 : 'right',  // left arrow
+					38 : 'down'    // up arrow
+				},
+				close  : [27], // escape key
+				play   : [32], // space - start/stop slideshow
+				toggle : [70]  // letter "f" - toggle fullscreen
+			},
 
-            direction: {
-                next: 'left',
-                prev: 'right'
-            },
+			direction : {
+				next : 'left',
+				prev : 'right'
+			},
 
-            scrollOutside: true,
+			scrollOutside  : true,
 
-            // Override some properties
-            index: 0,
-            type: null,
-            href: null,
-            content: null,
-            title: null,
+			// Override some properties
+			index   : 0,
+			type    : null,
+			href    : null,
+			content : null,
+			title   : null,
 
-            // HTML templates
-            tpl: {
-                wrap: '<div class="fancybox-wrap" tabIndex="-1"><div class="fancybox-skin"><div class="fancybox-outer"><div class="fancybox-inner"></div></div></div></div>',
-                image: '<img class="fancybox-image" src="{href}" alt="" />',
-                iframe: '<iframe id="fancybox-frame{rnd}" name="fancybox-frame{rnd}" class="fancybox-iframe" frameborder="0" vspace="0" hspace="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen' + (IE ? ' allowtransparency="true"' : '') + '></iframe>',
-                error: '<p class="fancybox-error">The requested content cannot be loaded.<br/>Please try again later.</p>',
-                closeBtn: '<a title="Close" class="fancybox-item fancybox-close" href="javascript:;"></a>',
-                next: '<a title="Next" class="fancybox-nav fancybox-next" href="javascript:;"><span></span></a>',
-                prev: '<a title="Previous" class="fancybox-nav fancybox-prev" href="javascript:;"><span></span></a>',
-                loading: '<div id="fancybox-loading"><div></div></div>'
-            },
+			// HTML templates
+			tpl: {
+				wrap     : '<div class="fancybox-wrap" tabIndex="-1"><div class="fancybox-skin"><div class="fancybox-outer"><div class="fancybox-inner"></div></div></div></div>',
+				image    : '<img class="fancybox-image" src="{href}" alt="" />',
+				iframe   : '<iframe id="fancybox-frame{rnd}" name="fancybox-frame{rnd}" class="fancybox-iframe" frameborder="0" vspace="0" hspace="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen' + (IE ? ' allowtransparency="true"' : '') + '></iframe>',
+				error    : '<p class="fancybox-error">The requested content cannot be loaded.<br/>Please try again later.</p>',
+				closeBtn : '<a title="Close" class="fancybox-item fancybox-close" href="javascript:;"></a>',
+				next     : '<a title="Next" class="fancybox-nav fancybox-next" href="javascript:;"><span></span></a>',
+				prev     : '<a title="Previous" class="fancybox-nav fancybox-prev" href="javascript:;"><span></span></a>',
+				loading  : '<div id="fancybox-loading"><div></div></div>'
+			},
 
-            // Properties for each animation type
-            // Opening fancyBox
-            openEffect: 'fade', // 'elastic', 'fade' or 'none'
-            openSpeed: 250,
-            openEasing: 'swing',
-            openOpacity: true,
-            openMethod: 'zoomIn',
+			// Properties for each animation type
+			// Opening fancyBox
+			openEffect  : 'fade', // 'elastic', 'fade' or 'none'
+			openSpeed   : 250,
+			openEasing  : 'swing',
+			openOpacity : true,
+			openMethod  : 'zoomIn',
 
-            // Closing fancyBox
-            closeEffect: 'fade', // 'elastic', 'fade' or 'none'
-            closeSpeed: 250,
-            closeEasing: 'swing',
-            closeOpacity: true,
-            closeMethod: 'zoomOut',
+			// Closing fancyBox
+			closeEffect  : 'fade', // 'elastic', 'fade' or 'none'
+			closeSpeed   : 250,
+			closeEasing  : 'swing',
+			closeOpacity : true,
+			closeMethod  : 'zoomOut',
 
-            // Changing next gallery item
-            nextEffect: 'elastic', // 'elastic', 'fade' or 'none'
-            nextSpeed: 250,
-            nextEasing: 'swing',
-            nextMethod: 'changeIn',
+			// Changing next gallery item
+			nextEffect : 'elastic', // 'elastic', 'fade' or 'none'
+			nextSpeed  : 250,
+			nextEasing : 'swing',
+			nextMethod : 'changeIn',
 
-            // Changing previous gallery item
-            prevEffect: 'elastic', // 'elastic', 'fade' or 'none'
-            prevSpeed: 250,
-            prevEasing: 'swing',
-            prevMethod: 'changeOut',
+			// Changing previous gallery item
+			prevEffect : 'elastic', // 'elastic', 'fade' or 'none'
+			prevSpeed  : 250,
+			prevEasing : 'swing',
+			prevMethod : 'changeOut',
 
-            // Enable default helpers
-            helpers: {
-                overlay: true,
-                title: true
-            },
+			// Enable default helpers
+			helpers : {
+				overlay : true,
+				title   : true
+			},
 
-            // Callbacks
-            onCancel: $.noop, // If canceling
-            beforeLoad: $.noop, // Before loading
-            afterLoad: $.noop, // After loading
-            beforeShow: $.noop, // Before changing in current item
-            afterShow: $.noop, // After opening
-            beforeChange: $.noop, // Before changing gallery item
-            beforeClose: $.noop, // Before closing
-            afterClose: $.noop  // After closing
-        },
+			// Callbacks
+			onCancel     : $.noop, // If canceling
+			beforeLoad   : $.noop, // Before loading
+			afterLoad    : $.noop, // After loading
+			beforeShow   : $.noop, // Before changing in current item
+			afterShow    : $.noop, // After opening
+			beforeChange : $.noop, // Before changing gallery item
+			beforeClose  : $.noop, // Before closing
+			afterClose   : $.noop  // After closing
+		},
 
-        //Current state
-        group: {}, // Selected group
-        opts: {}, // Group options
-        previous: null,  // Previous element
-        coming: null,  // Element being loaded
-        current: null,  // Currently loaded element
-        isActive: false, // Is activated
-        isOpen: false, // Is currently open
-        isOpened: false, // Have been fully opened at least once
+		//Current state
+		group    : {}, // Selected group
+		opts     : {}, // Group options
+		previous : null,  // Previous element
+		coming   : null,  // Element being loaded
+		current  : null,  // Currently loaded element
+		isActive : false, // Is activated
+		isOpen   : false, // Is currently open
+		isOpened : false, // Have been fully opened at least once
 
-        wrap: null,
-        skin: null,
-        outer: null,
-        inner: null,
+		wrap  : null,
+		skin  : null,
+		outer : null,
+		inner : null,
 
-        player: {
-            timer: null,
-            isActive: false
-        },
+		player : {
+			timer    : null,
+			isActive : false
+		},
 
-        // Loaders
-        ajaxLoad: null,
-        imgPreload: null,
+		// Loaders
+		ajaxLoad   : null,
+		imgPreload : null,
 
-        // Some collections
-        transitions: {},
-        helpers: {},
+		// Some collections
+		transitions : {},
+		helpers     : {},
 
-        /*
+		/*
 		 *	Static methods
 		 */
 
-        open: function (group, opts) {
-            if (!group) {
-                return;
-            }
+		open: function (group, opts) {
+			if (!group) {
+				return;
+			}
 
-            if (!$.isPlainObject(opts)) {
-                opts = {};
-            }
+			if (!$.isPlainObject(opts)) {
+				opts = {};
+			}
 
-            // Close if already active
-            if (false === F.close(true)) {
-                return;
-            }
+			// Close if already active
+			if (false === F.close(true)) {
+				return;
+			}
 
-            // Normalize group
-            if (!$.isArray(group)) {
-                group = isQuery(group) ? $(group).get() : [group];
-            }
+			// Normalize group
+			if (!$.isArray(group)) {
+				group = isQuery(group) ? $(group).get() : [group];
+			}
 
-            // Recheck if the type of each element is `object` and set content type (image, ajax, etc)
-            $.each(group, function (i, element) {
-                var obj = {},
+			// Recheck if the type of each element is `object` and set content type (image, ajax, etc)
+			$.each(group, function(i, element) {
+				var obj = {},
 					href,
 					title,
 					content,
@@ -5402,803 +5402,803 @@ var fakewaffle = (function ($, fakewaffle) {
 					hrefParts,
 					selector;
 
-                if ($.type(element) === "object") {
-                    // Check if is DOM element
-                    if (element.nodeType) {
-                        element = $(element);
-                    }
+				if ($.type(element) === "object") {
+					// Check if is DOM element
+					if (element.nodeType) {
+						element = $(element);
+					}
 
-                    if (isQuery(element)) {
-                        obj = {
-                            href: element.data('fancybox-href') || element.attr('href'),
-                            title: $('<div/>').text(element.data('fancybox-title') || element.attr('title') || '').html(),
-                            isDom: true,
-                            element: element
-                        };
+					if (isQuery(element)) {
+						obj = {
+							href    : element.data('fancybox-href') || element.attr('href'),
+							title   : $('<div/>').text( element.data('fancybox-title') || element.attr('title') || '' ).html(),
+							isDom   : true,
+							element : element
+						};
 
-                        if ($.metadata) {
-                            $.extend(true, obj, element.metadata());
-                        }
+						if ($.metadata) {
+							$.extend(true, obj, element.metadata());
+						}
 
-                    } else {
-                        obj = element;
-                    }
-                }
+					} else {
+						obj = element;
+					}
+				}
 
-                href = opts.href || obj.href || (isString(element) ? element : null);
-                title = opts.title !== undefined ? opts.title : obj.title || '';
+				href  = opts.href  || obj.href || (isString(element) ? element : null);
+				title = opts.title !== undefined ? opts.title : obj.title || '';
 
-                content = opts.content || obj.content;
-                type = content ? 'html' : (opts.type || obj.type);
+				content = opts.content || obj.content;
+				type    = content ? 'html' : (opts.type  || obj.type);
 
-                if (!type && obj.isDom) {
-                    type = element.data('fancybox-type');
+				if (!type && obj.isDom) {
+					type = element.data('fancybox-type');
 
-                    if (!type) {
-                        rez = element.prop('class').match(/fancybox\.(\w+)/);
-                        type = rez ? rez[1] : null;
-                    }
-                }
+					if (!type) {
+						rez  = element.prop('class').match(/fancybox\.(\w+)/);
+						type = rez ? rez[1] : null;
+					}
+				}
 
-                if (isString(href)) {
-                    // Try to guess the content type
-                    if (!type) {
-                        if (F.isImage(href)) {
-                            type = 'image';
+				if (isString(href)) {
+					// Try to guess the content type
+					if (!type) {
+						if (F.isImage(href)) {
+							type = 'image';
 
-                        } else if (F.isSWF(href)) {
-                            type = 'swf';
+						} else if (F.isSWF(href)) {
+							type = 'swf';
 
-                        } else if (href.charAt(0) === '#') {
-                            type = 'inline';
+						} else if (href.charAt(0) === '#') {
+							type = 'inline';
 
-                        } else if (isString(element)) {
-                            type = 'html';
-                            content = element;
-                        }
-                    }
+						} else if (isString(element)) {
+							type    = 'html';
+							content = element;
+						}
+					}
 
-                    // Split url into two pieces with source url and content selector, e.g,
-                    // "/mypage.html #my_id" will load "/mypage.html" and display element having id "my_id"
-                    if (type === 'ajax') {
-                        hrefParts = href.split(/\s+/, 2);
-                        href = hrefParts.shift();
-                        selector = hrefParts.shift();
-                    }
-                }
+					// Split url into two pieces with source url and content selector, e.g,
+					// "/mypage.html #my_id" will load "/mypage.html" and display element having id "my_id"
+					if (type === 'ajax') {
+						hrefParts = href.split(/\s+/, 2);
+						href      = hrefParts.shift();
+						selector  = hrefParts.shift();
+					}
+				}
 
-                if (!content) {
-                    if (type === 'inline') {
-                        if (href) {
-                            content = $(isString(href) ? href.replace(/.*(?=#[^\s]+$)/, '') : href); //strip for ie7
+				if (!content) {
+					if (type === 'inline') {
+						if (href) {
+							content = $( isString(href) ? href.replace(/.*(?=#[^\s]+$)/, '') : href ); //strip for ie7
 
-                        } else if (obj.isDom) {
-                            content = element;
-                        }
+						} else if (obj.isDom) {
+							content = element;
+						}
 
-                    } else if (type === 'html') {
-                        content = href;
+					} else if (type === 'html') {
+						content = href;
 
-                    } else if (!type && !href && obj.isDom) {
-                        type = 'inline';
-                        content = element;
-                    }
-                }
+					} else if (!type && !href && obj.isDom) {
+						type    = 'inline';
+						content = element;
+					}
+				}
 
-                $.extend(obj, {
-                    href: href,
-                    type: type,
-                    content: content,
-                    title: title,
-                    selector: selector
-                });
+				$.extend(obj, {
+					href     : href,
+					type     : type,
+					content  : content,
+					title    : title,
+					selector : selector
+				});
 
-                group[i] = obj;
-            });
+				group[ i ] = obj;
+			});
 
-            // Extend the defaults
-            F.opts = $.extend(true, {}, F.defaults, opts);
+			// Extend the defaults
+			F.opts = $.extend(true, {}, F.defaults, opts);
 
-            // All options are merged recursive except keys
-            if (opts.keys !== undefined) {
-                F.opts.keys = opts.keys ? $.extend({}, F.defaults.keys, opts.keys) : false;
-            }
+			// All options are merged recursive except keys
+			if (opts.keys !== undefined) {
+				F.opts.keys = opts.keys ? $.extend({}, F.defaults.keys, opts.keys) : false;
+			}
 
-            F.group = group;
+			F.group = group;
 
-            return F._start(F.opts.index);
-        },
+			return F._start(F.opts.index);
+		},
 
-        // Cancel image loading or abort ajax request
-        cancel: function () {
-            var coming = F.coming;
+		// Cancel image loading or abort ajax request
+		cancel: function () {
+			var coming = F.coming;
 
-            if (coming && false === F.trigger('onCancel')) {
-                return;
-            }
+			if (coming && false === F.trigger('onCancel')) {
+				return;
+			}
 
-            F.hideLoading();
+			F.hideLoading();
 
-            if (!coming) {
-                return;
-            }
+			if (!coming) {
+				return;
+			}
 
-            if (F.ajaxLoad) {
-                F.ajaxLoad.abort();
-            }
+			if (F.ajaxLoad) {
+				F.ajaxLoad.abort();
+			}
 
-            F.ajaxLoad = null;
+			F.ajaxLoad = null;
 
-            if (F.imgPreload) {
-                F.imgPreload.onload = F.imgPreload.onerror = null;
-            }
+			if (F.imgPreload) {
+				F.imgPreload.onload = F.imgPreload.onerror = null;
+			}
 
-            if (coming.wrap) {
-                coming.wrap.stop(true, true).trigger('onReset').remove();
-            }
+			if (coming.wrap) {
+				coming.wrap.stop(true, true).trigger('onReset').remove();
+			}
 
-            F.coming = null;
+			F.coming = null;
 
-            // If the first item has been canceled, then clear everything
-            if (!F.current) {
-                F._afterZoomOut(coming);
-            }
-        },
+			// If the first item has been canceled, then clear everything
+			if (!F.current) {
+				F._afterZoomOut( coming );
+			}
+		},
 
-        // Start closing animation if is open; remove immediately if opening/closing
-        close: function (event) {
-            F.cancel();
+		// Start closing animation if is open; remove immediately if opening/closing
+		close: function (event) {
+			F.cancel();
 
-            if (false === F.trigger('beforeClose')) {
-                return;
-            }
+			if (false === F.trigger('beforeClose')) {
+				return;
+			}
 
-            F.unbindEvents();
+			F.unbindEvents();
 
-            if (!F.isActive) {
-                return;
-            }
+			if (!F.isActive) {
+				return;
+			}
 
-            if (!F.isOpen || event === true) {
-                $('.fancybox-wrap').stop(true).trigger('onReset').remove();
+			if (!F.isOpen || event === true) {
+				$('.fancybox-wrap').stop(true).trigger('onReset').remove();
 
-                F._afterZoomOut();
+				F._afterZoomOut();
 
-            } else {
-                F.isOpen = F.isOpened = false;
-                F.isClosing = true;
+			} else {
+				F.isOpen = F.isOpened = false;
+				F.isClosing = true;
 
-                $('.fancybox-item, .fancybox-nav').remove();
+				$('.fancybox-item, .fancybox-nav').remove();
 
-                F.wrap.stop(true, true).removeClass('fancybox-opened');
+				F.wrap.stop(true, true).removeClass('fancybox-opened');
 
-                F.transitions[F.current.closeMethod]();
-            }
-        },
+				F.transitions[ F.current.closeMethod ]();
+			}
+		},
 
-        // Manage slideshow:
-        //   $.fancybox.play(); - toggle slideshow
-        //   $.fancybox.play( true ); - start
-        //   $.fancybox.play( false ); - stop
-        play: function (action) {
-            var clear = function () {
-                clearTimeout(F.player.timer);
-            },
+		// Manage slideshow:
+		//   $.fancybox.play(); - toggle slideshow
+		//   $.fancybox.play( true ); - start
+		//   $.fancybox.play( false ); - stop
+		play: function ( action ) {
+			var clear = function () {
+					clearTimeout(F.player.timer);
+				},
 				set = function () {
-				    clear();
+					clear();
 
-				    if (F.current && F.player.isActive) {
-				        F.player.timer = setTimeout(F.next, F.current.playSpeed);
-				    }
+					if (F.current && F.player.isActive) {
+						F.player.timer = setTimeout(F.next, F.current.playSpeed);
+					}
 				},
 				stop = function () {
-				    clear();
+					clear();
 
-				    D.unbind('.player');
+					D.unbind('.player');
 
-				    F.player.isActive = false;
+					F.player.isActive = false;
 
-				    F.trigger('onPlayEnd');
+					F.trigger('onPlayEnd');
 				},
 				start = function () {
-				    if (F.current && (F.current.loop || F.current.index < F.group.length - 1)) {
-				        F.player.isActive = true;
+					if (F.current && (F.current.loop || F.current.index < F.group.length - 1)) {
+						F.player.isActive = true;
 
-				        D.bind({
-				            'onCancel.player beforeClose.player': stop,
-				            'onUpdate.player': set,
-				            'beforeLoad.player': clear
-				        });
+						D.bind({
+							'onCancel.player beforeClose.player' : stop,
+							'onUpdate.player'   : set,
+							'beforeLoad.player' : clear
+						});
 
-				        set();
+						set();
 
-				        F.trigger('onPlayStart');
-				    }
+						F.trigger('onPlayStart');
+					}
 				};
 
-            if (action === true || (!F.player.isActive && action !== false)) {
-                start();
-            } else {
-                stop();
-            }
-        },
+			if (action === true || (!F.player.isActive && action !== false)) {
+				start();
+			} else {
+				stop();
+			}
+		},
 
-        // Navigate to next gallery item
-        next: function (direction) {
-            var current = F.current;
+		// Navigate to next gallery item
+		next: function ( direction ) {
+			var current = F.current;
 
-            if (current) {
-                if (!isString(direction)) {
-                    direction = current.direction.next;
-                }
+			if (current) {
+				if (!isString(direction)) {
+					direction = current.direction.next;
+				}
 
-                F.jumpto(current.index + 1, direction, 'next');
-            }
-        },
+				F.jumpto(current.index + 1, direction, 'next');
+			}
+		},
 
-        // Navigate to previous gallery item
-        prev: function (direction) {
-            var current = F.current;
+		// Navigate to previous gallery item
+		prev: function ( direction ) {
+			var current = F.current;
 
-            if (current) {
-                if (!isString(direction)) {
-                    direction = current.direction.prev;
-                }
+			if (current) {
+				if (!isString(direction)) {
+					direction = current.direction.prev;
+				}
 
-                F.jumpto(current.index - 1, direction, 'prev');
-            }
-        },
+				F.jumpto(current.index - 1, direction, 'prev');
+			}
+		},
 
-        // Navigate to gallery item by index
-        jumpto: function (index, direction, router) {
-            var current = F.current;
+		// Navigate to gallery item by index
+		jumpto: function ( index, direction, router ) {
+			var current = F.current;
 
-            if (!current) {
-                return;
-            }
+			if (!current) {
+				return;
+			}
 
-            index = getScalar(index);
+			index = getScalar(index);
 
-            F.direction = direction || current.direction[(index >= current.index ? 'next' : 'prev')];
-            F.router = router || 'jumpto';
+			F.direction = direction || current.direction[ (index >= current.index ? 'next' : 'prev') ];
+			F.router    = router || 'jumpto';
 
-            if (current.loop) {
-                if (index < 0) {
-                    index = current.group.length + (index % current.group.length);
-                }
+			if (current.loop) {
+				if (index < 0) {
+					index = current.group.length + (index % current.group.length);
+				}
 
-                index = index % current.group.length;
-            }
+				index = index % current.group.length;
+			}
 
-            if (current.group[index] !== undefined) {
-                F.cancel();
+			if (current.group[ index ] !== undefined) {
+				F.cancel();
 
-                F._start(index);
-            }
-        },
+				F._start(index);
+			}
+		},
 
-        // Center inside viewport and toggle position type to fixed or absolute if needed
-        reposition: function (e, onlyAbsolute) {
-            var current = F.current,
-				wrap = current ? current.wrap : null,
+		// Center inside viewport and toggle position type to fixed or absolute if needed
+		reposition: function (e, onlyAbsolute) {
+			var current = F.current,
+				wrap    = current ? current.wrap : null,
 				pos;
 
-            if (wrap) {
-                pos = F._getPosition(onlyAbsolute);
+			if (wrap) {
+				pos = F._getPosition(onlyAbsolute);
 
-                if (e && e.type === 'scroll') {
-                    delete pos.position;
+				if (e && e.type === 'scroll') {
+					delete pos.position;
 
-                    wrap.stop(true, true).animate(pos, 200);
+					wrap.stop(true, true).animate(pos, 200);
 
-                } else {
-                    wrap.css(pos);
+				} else {
+					wrap.css(pos);
 
-                    current.pos = $.extend({}, current.dim, pos);
-                }
-            }
-        },
+					current.pos = $.extend({}, current.dim, pos);
+				}
+			}
+		},
 
-        update: function (e) {
-            var type = (e && e.originalEvent && e.originalEvent.type),
+		update: function (e) {
+			var type = (e && e.originalEvent && e.originalEvent.type),
 				anyway = !type || type === 'orientationchange';
 
-            if (anyway) {
-                clearTimeout(didUpdate);
+			if (anyway) {
+				clearTimeout(didUpdate);
 
-                didUpdate = null;
-            }
+				didUpdate = null;
+			}
 
-            if (!F.isOpen || didUpdate) {
-                return;
-            }
+			if (!F.isOpen || didUpdate) {
+				return;
+			}
 
-            didUpdate = setTimeout(function () {
-                var current = F.current;
+			didUpdate = setTimeout(function() {
+				var current = F.current;
 
-                if (!current || F.isClosing) {
-                    return;
-                }
+				if (!current || F.isClosing) {
+					return;
+				}
 
-                F.wrap.removeClass('fancybox-tmp');
+				F.wrap.removeClass('fancybox-tmp');
 
-                if (anyway || type === 'load' || (type === 'resize' && current.autoResize)) {
-                    F._setDimension();
-                }
+				if (anyway || type === 'load' || (type === 'resize' && current.autoResize)) {
+					F._setDimension();
+				}
 
-                if (!(type === 'scroll' && current.canShrink)) {
-                    F.reposition(e);
-                }
+				if (!(type === 'scroll' && current.canShrink)) {
+					F.reposition(e);
+				}
 
-                F.trigger('onUpdate');
+				F.trigger('onUpdate');
 
-                didUpdate = null;
+				didUpdate = null;
 
-            }, (anyway && !isTouch ? 0 : 300));
-        },
+			}, (anyway && !isTouch ? 0 : 300));
+		},
 
-        // Shrink content to fit inside viewport or restore if resized
-        toggle: function (action) {
-            if (F.isOpen) {
-                F.current.fitToView = $.type(action) === "boolean" ? action : !F.current.fitToView;
+		// Shrink content to fit inside viewport or restore if resized
+		toggle: function ( action ) {
+			if (F.isOpen) {
+				F.current.fitToView = $.type(action) === "boolean" ? action : !F.current.fitToView;
 
-                // Help browser to restore document dimensions
-                if (isTouch) {
-                    F.wrap.removeAttr('style').addClass('fancybox-tmp');
+				// Help browser to restore document dimensions
+				if (isTouch) {
+					F.wrap.removeAttr('style').addClass('fancybox-tmp');
 
-                    F.trigger('onUpdate');
-                }
+					F.trigger('onUpdate');
+				}
 
-                F.update();
-            }
-        },
+				F.update();
+			}
+		},
 
-        hideLoading: function () {
-            D.unbind('.loading');
+		hideLoading: function () {
+			D.unbind('.loading');
 
-            $('#fancybox-loading').remove();
-        },
+			$('#fancybox-loading').remove();
+		},
 
-        showLoading: function () {
-            var el, viewport;
+		showLoading: function () {
+			var el, viewport;
 
-            F.hideLoading();
+			F.hideLoading();
 
-            el = $(F.opts.tpl.loading).click(F.cancel).appendTo('body');
+			el = $(F.opts.tpl.loading).click(F.cancel).appendTo('body');
 
-            // If user will press the escape-button, the request will be canceled
-            D.bind('keydown.loading', function (e) {
-                if ((e.which || e.keyCode) === 27) {
-                    e.preventDefault();
+			// If user will press the escape-button, the request will be canceled
+			D.bind('keydown.loading', function(e) {
+				if ((e.which || e.keyCode) === 27) {
+					e.preventDefault();
 
-                    F.cancel();
-                }
-            });
+					F.cancel();
+				}
+			});
 
-            if (!F.defaults.fixed) {
-                viewport = F.getViewport();
+			if (!F.defaults.fixed) {
+				viewport = F.getViewport();
 
-                el.css({
-                    position: 'absolute',
-                    top: (viewport.h * 0.5) + viewport.y,
-                    left: (viewport.w * 0.5) + viewport.x
-                });
-            }
+				el.css({
+					position : 'absolute',
+					top  : (viewport.h * 0.5) + viewport.y,
+					left : (viewport.w * 0.5) + viewport.x
+				});
+			}
 
-            F.trigger('onLoading');
-        },
+			F.trigger('onLoading');
+		},
 
-        getViewport: function () {
-            var locked = (F.current && F.current.locked) || false,
-				rez = {
-				    x: W.scrollLeft(),
-				    y: W.scrollTop()
+		getViewport: function () {
+			var locked = (F.current && F.current.locked) || false,
+				rez    = {
+					x: W.scrollLeft(),
+					y: W.scrollTop()
 				};
 
-            if (locked && locked.length) {
-                rez.w = locked[0].clientWidth;
-                rez.h = locked[0].clientHeight;
+			if (locked && locked.length) {
+				rez.w = locked[0].clientWidth;
+				rez.h = locked[0].clientHeight;
 
-            } else {
-                // See http://bugs.jquery.com/ticket/6724
-                rez.w = isTouch && window.innerWidth ? window.innerWidth : W.width();
-                rez.h = isTouch && window.innerHeight ? window.innerHeight : W.height();
-            }
+			} else {
+				// See http://bugs.jquery.com/ticket/6724
+				rez.w = isTouch && window.innerWidth  ? window.innerWidth  : W.width();
+				rez.h = isTouch && window.innerHeight ? window.innerHeight : W.height();
+			}
 
-            return rez;
-        },
+			return rez;
+		},
 
-        // Unbind the keyboard / clicking actions
-        unbindEvents: function () {
-            if (F.wrap && isQuery(F.wrap)) {
-                F.wrap.unbind('.fb');
-            }
+		// Unbind the keyboard / clicking actions
+		unbindEvents: function () {
+			if (F.wrap && isQuery(F.wrap)) {
+				F.wrap.unbind('.fb');
+			}
 
-            D.unbind('.fb');
-            W.unbind('.fb');
-        },
+			D.unbind('.fb');
+			W.unbind('.fb');
+		},
 
-        bindEvents: function () {
-            var current = F.current,
+		bindEvents: function () {
+			var current = F.current,
 				keys;
 
-            if (!current) {
-                return;
-            }
+			if (!current) {
+				return;
+			}
 
-            // Changing document height on iOS devices triggers a 'resize' event,
-            // that can change document height... repeating infinitely
-            W.bind('orientationchange.fb' + (isTouch ? '' : ' resize.fb') + (current.autoCenter && !current.locked ? ' scroll.fb' : ''), F.update);
+			// Changing document height on iOS devices triggers a 'resize' event,
+			// that can change document height... repeating infinitely
+			W.bind('orientationchange.fb' + (isTouch ? '' : ' resize.fb') + (current.autoCenter && !current.locked ? ' scroll.fb' : ''), F.update);
 
-            keys = current.keys;
+			keys = current.keys;
 
-            if (keys) {
-                D.bind('keydown.fb', function (e) {
-                    var code = e.which || e.keyCode,
+			if (keys) {
+				D.bind('keydown.fb', function (e) {
+					var code   = e.which || e.keyCode,
 						target = e.target || e.srcElement;
 
-                    // Skip esc key if loading, because showLoading will cancel preloading
-                    if (code === 27 && F.coming) {
-                        return false;
-                    }
+					// Skip esc key if loading, because showLoading will cancel preloading
+					if (code === 27 && F.coming) {
+						return false;
+					}
 
-                    // Ignore key combinations and key events within form elements
-                    if (!e.ctrlKey && !e.altKey && !e.shiftKey && !e.metaKey && !(target && (target.type || $(target).is('[contenteditable]')))) {
-                        $.each(keys, function (i, val) {
-                            if (current.group.length > 1 && val[code] !== undefined) {
-                                F[i](val[code]);
+					// Ignore key combinations and key events within form elements
+					if (!e.ctrlKey && !e.altKey && !e.shiftKey && !e.metaKey && !(target && (target.type || $(target).is('[contenteditable]')))) {
+						$.each(keys, function(i, val) {
+							if (current.group.length > 1 && val[ code ] !== undefined) {
+								F[ i ]( val[ code ] );
 
-                                e.preventDefault();
-                                return false;
-                            }
+								e.preventDefault();
+								return false;
+							}
 
-                            if ($.inArray(code, val) > -1) {
-                                F[i]();
+							if ($.inArray(code, val) > -1) {
+								F[ i ] ();
 
-                                e.preventDefault();
-                                return false;
-                            }
-                        });
-                    }
-                });
-            }
+								e.preventDefault();
+								return false;
+							}
+						});
+					}
+				});
+			}
 
-            if ($.fn.mousewheel && current.mouseWheel) {
-                F.wrap.bind('mousewheel.fb', function (e, delta, deltaX, deltaY) {
-                    var target = e.target || null,
+			if ($.fn.mousewheel && current.mouseWheel) {
+				F.wrap.bind('mousewheel.fb', function (e, delta, deltaX, deltaY) {
+					var target = e.target || null,
 						parent = $(target),
 						canScroll = false;
 
-                    while (parent.length) {
-                        if (canScroll || parent.is('.fancybox-skin') || parent.is('.fancybox-wrap')) {
-                            break;
-                        }
+					while (parent.length) {
+						if (canScroll || parent.is('.fancybox-skin') || parent.is('.fancybox-wrap')) {
+							break;
+						}
 
-                        canScroll = isScrollable(parent[0]);
-                        parent = $(parent).parent();
-                    }
+						canScroll = isScrollable( parent[0] );
+						parent    = $(parent).parent();
+					}
 
-                    if (delta !== 0 && !canScroll) {
-                        if (F.group.length > 1 && !current.canShrink) {
-                            if (deltaY > 0 || deltaX > 0) {
-                                F.prev(deltaY > 0 ? 'down' : 'left');
+					if (delta !== 0 && !canScroll) {
+						if (F.group.length > 1 && !current.canShrink) {
+							if (deltaY > 0 || deltaX > 0) {
+								F.prev( deltaY > 0 ? 'down' : 'left' );
 
-                            } else if (deltaY < 0 || deltaX < 0) {
-                                F.next(deltaY < 0 ? 'up' : 'right');
-                            }
+							} else if (deltaY < 0 || deltaX < 0) {
+								F.next( deltaY < 0 ? 'up' : 'right' );
+							}
 
-                            e.preventDefault();
-                        }
-                    }
-                });
-            }
-        },
+							e.preventDefault();
+						}
+					}
+				});
+			}
+		},
 
-        trigger: function (event, o) {
-            var ret, obj = o || F.coming || F.current;
+		trigger: function (event, o) {
+			var ret, obj = o || F.coming || F.current;
 
-            if (obj) {
-                if ($.isFunction(obj[event])) {
-                    ret = obj[event].apply(obj, Array.prototype.slice.call(arguments, 1));
-                }
+			if (obj) {
+				if ($.isFunction( obj[event] )) {
+					ret = obj[event].apply(obj, Array.prototype.slice.call(arguments, 1));
+				}
 
-                if (ret === false) {
-                    return false;
-                }
+				if (ret === false) {
+					return false;
+				}
 
-                if (obj.helpers) {
-                    $.each(obj.helpers, function (helper, opts) {
-                        if (opts && F.helpers[helper] && $.isFunction(F.helpers[helper][event])) {
-                            F.helpers[helper][event]($.extend(true, {}, F.helpers[helper].defaults, opts), obj);
-                        }
-                    });
-                }
-            }
+				if (obj.helpers) {
+					$.each(obj.helpers, function (helper, opts) {
+						if (opts && F.helpers[helper] && $.isFunction(F.helpers[helper][event])) {
+							F.helpers[helper][event]($.extend(true, {}, F.helpers[helper].defaults, opts), obj);
+						}
+					});
+				}
+			}
 
-            D.trigger(event);
-        },
+			D.trigger(event);
+		},
 
-        isImage: function (str) {
-            return isString(str) && str.match(/(^data:image\/.*,)|(\.(jp(e|g|eg)|gif|png|bmp|webp|svg)((\?|#).*)?$)/i);
-        },
+		isImage: function (str) {
+			return isString(str) && str.match(/(^data:image\/.*,)|(\.(jp(e|g|eg)|gif|png|bmp|webp|svg)((\?|#).*)?$)/i);
+		},
 
-        isSWF: function (str) {
-            return isString(str) && str.match(/\.(swf)((\?|#).*)?$/i);
-        },
+		isSWF: function (str) {
+			return isString(str) && str.match(/\.(swf)((\?|#).*)?$/i);
+		},
 
-        _start: function (index) {
-            var coming = {},
+		_start: function (index) {
+			var coming = {},
 				obj,
 				href,
 				type,
 				margin,
 				padding;
 
-            index = getScalar(index);
-            obj = F.group[index] || null;
+			index = getScalar( index );
+			obj   = F.group[ index ] || null;
 
-            if (!obj) {
-                return false;
-            }
+			if (!obj) {
+				return false;
+			}
 
-            coming = $.extend(true, {}, F.opts, obj);
+			coming = $.extend(true, {}, F.opts, obj);
 
-            // Convert margin and padding properties to array - top, right, bottom, left
-            margin = coming.margin;
-            padding = coming.padding;
+			// Convert margin and padding properties to array - top, right, bottom, left
+			margin  = coming.margin;
+			padding = coming.padding;
 
-            if ($.type(margin) === 'number') {
-                coming.margin = [margin, margin, margin, margin];
-            }
+			if ($.type(margin) === 'number') {
+				coming.margin = [margin, margin, margin, margin];
+			}
 
-            if ($.type(padding) === 'number') {
-                coming.padding = [padding, padding, padding, padding];
-            }
+			if ($.type(padding) === 'number') {
+				coming.padding = [padding, padding, padding, padding];
+			}
 
-            // 'modal' propery is just a shortcut
-            if (coming.modal) {
-                $.extend(true, coming, {
-                    closeBtn: false,
-                    closeClick: false,
-                    nextClick: false,
-                    arrows: false,
-                    mouseWheel: false,
-                    keys: null,
-                    helpers: {
-                        overlay: {
-                            closeClick: false
-                        }
-                    }
-                });
-            }
+			// 'modal' propery is just a shortcut
+			if (coming.modal) {
+				$.extend(true, coming, {
+					closeBtn   : false,
+					closeClick : false,
+					nextClick  : false,
+					arrows     : false,
+					mouseWheel : false,
+					keys       : null,
+					helpers: {
+						overlay : {
+							closeClick : false
+						}
+					}
+				});
+			}
 
-            // 'autoSize' property is a shortcut, too
-            if (coming.autoSize) {
-                coming.autoWidth = coming.autoHeight = true;
-            }
+			// 'autoSize' property is a shortcut, too
+			if (coming.autoSize) {
+				coming.autoWidth = coming.autoHeight = true;
+			}
 
-            if (coming.width === 'auto') {
-                coming.autoWidth = true;
-            }
+			if (coming.width === 'auto') {
+				coming.autoWidth = true;
+			}
 
-            if (coming.height === 'auto') {
-                coming.autoHeight = true;
-            }
+			if (coming.height === 'auto') {
+				coming.autoHeight = true;
+			}
 
-            /*
+			/*
 			 * Add reference to the group, so it`s possible to access from callbacks, example:
 			 * afterLoad : function() {
 			 *     this.title = 'Image ' + (this.index + 1) + ' of ' + this.group.length + (this.title ? ' - ' + this.title : '');
 			 * }
 			 */
 
-            coming.group = F.group;
-            coming.index = index;
+			coming.group  = F.group;
+			coming.index  = index;
 
-            // Give a chance for callback or helpers to update coming item (type, title, etc)
-            F.coming = coming;
+			// Give a chance for callback or helpers to update coming item (type, title, etc)
+			F.coming = coming;
 
-            if (false === F.trigger('beforeLoad')) {
-                F.coming = null;
+			if (false === F.trigger('beforeLoad')) {
+				F.coming = null;
 
-                return;
-            }
+				return;
+			}
 
-            type = coming.type;
-            href = coming.href;
+			type = coming.type;
+			href = coming.href;
 
-            if (!type) {
-                F.coming = null;
+			if (!type) {
+				F.coming = null;
 
-                //If we can not determine content type then drop silently or display next/prev item if looping through gallery
-                if (F.current && F.router && F.router !== 'jumpto') {
-                    F.current.index = index;
+				//If we can not determine content type then drop silently or display next/prev item if looping through gallery
+				if (F.current && F.router && F.router !== 'jumpto') {
+					F.current.index = index;
 
-                    return F[F.router](F.direction);
-                }
+					return F[ F.router ]( F.direction );
+				}
 
-                return false;
-            }
+				return false;
+			}
 
-            F.isActive = true;
+			F.isActive = true;
 
-            if (type === 'image' || type === 'swf') {
-                coming.autoHeight = coming.autoWidth = false;
-                coming.scrolling = 'visible';
-            }
+			if (type === 'image' || type === 'swf') {
+				coming.autoHeight = coming.autoWidth = false;
+				coming.scrolling  = 'visible';
+			}
 
-            if (type === 'image') {
-                coming.aspectRatio = true;
-            }
+			if (type === 'image') {
+				coming.aspectRatio = true;
+			}
 
-            if (type === 'iframe' && isTouch) {
-                coming.scrolling = 'scroll';
-            }
+			if (type === 'iframe' && isTouch) {
+				coming.scrolling = 'scroll';
+			}
 
-            // Build the neccessary markup
-            coming.wrap = $(coming.tpl.wrap).addClass('fancybox-' + (isTouch ? 'mobile' : 'desktop') + ' fancybox-type-' + type + ' fancybox-tmp ' + coming.wrapCSS).appendTo(coming.parent || 'body');
+			// Build the neccessary markup
+			coming.wrap = $(coming.tpl.wrap).addClass('fancybox-' + (isTouch ? 'mobile' : 'desktop') + ' fancybox-type-' + type + ' fancybox-tmp ' + coming.wrapCSS).appendTo( coming.parent || 'body' );
 
-            $.extend(coming, {
-                skin: $('.fancybox-skin', coming.wrap),
-                outer: $('.fancybox-outer', coming.wrap),
-                inner: $('.fancybox-inner', coming.wrap)
-            });
+			$.extend(coming, {
+				skin  : $('.fancybox-skin',  coming.wrap),
+				outer : $('.fancybox-outer', coming.wrap),
+				inner : $('.fancybox-inner', coming.wrap)
+			});
 
-            $.each(["Top", "Right", "Bottom", "Left"], function (i, v) {
-                coming.skin.css('padding' + v, getValue(coming.padding[i]));
-            });
+			$.each(["Top", "Right", "Bottom", "Left"], function(i, v) {
+				coming.skin.css('padding' + v, getValue(coming.padding[ i ]));
+			});
 
-            F.trigger('onReady');
+			F.trigger('onReady');
 
-            // Check before try to load; 'inline' and 'html' types need content, others - href
-            if (type === 'inline' || type === 'html') {
-                if (!coming.content || !coming.content.length) {
-                    return F._error('content');
-                }
+			// Check before try to load; 'inline' and 'html' types need content, others - href
+			if (type === 'inline' || type === 'html') {
+				if (!coming.content || !coming.content.length) {
+					return F._error( 'content' );
+				}
 
-            } else if (!href) {
-                return F._error('href');
-            }
+			} else if (!href) {
+				return F._error( 'href' );
+			}
 
-            if (type === 'image') {
-                F._loadImage();
+			if (type === 'image') {
+				F._loadImage();
 
-            } else if (type === 'ajax') {
-                F._loadAjax();
+			} else if (type === 'ajax') {
+				F._loadAjax();
 
-            } else if (type === 'iframe') {
-                F._loadIframe();
+			} else if (type === 'iframe') {
+				F._loadIframe();
 
-            } else {
-                F._afterLoad();
-            }
-        },
+			} else {
+				F._afterLoad();
+			}
+		},
 
-        _error: function (type) {
-            $.extend(F.coming, {
-                type: 'html',
-                autoWidth: true,
-                autoHeight: true,
-                minWidth: 0,
-                minHeight: 0,
-                scrolling: 'no',
-                hasError: type,
-                content: F.coming.tpl.error
-            });
+		_error: function ( type ) {
+			$.extend(F.coming, {
+				type       : 'html',
+				autoWidth  : true,
+				autoHeight : true,
+				minWidth   : 0,
+				minHeight  : 0,
+				scrolling  : 'no',
+				hasError   : type,
+				content    : F.coming.tpl.error
+			});
 
-            F._afterLoad();
-        },
+			F._afterLoad();
+		},
 
-        _loadImage: function () {
-            // Reset preload image so it is later possible to check "complete" property
-            var img = F.imgPreload = new Image();
+		_loadImage: function () {
+			// Reset preload image so it is later possible to check "complete" property
+			var img = F.imgPreload = new Image();
 
-            img.onload = function () {
-                this.onload = this.onerror = null;
+			img.onload = function () {
+				this.onload = this.onerror = null;
 
-                F.coming.width = this.width / F.opts.pixelRatio;
-                F.coming.height = this.height / F.opts.pixelRatio;
+				F.coming.width  = this.width / F.opts.pixelRatio;
+				F.coming.height = this.height / F.opts.pixelRatio;
 
-                F._afterLoad();
-            };
+				F._afterLoad();
+			};
 
-            img.onerror = function () {
-                this.onload = this.onerror = null;
+			img.onerror = function () {
+				this.onload = this.onerror = null;
 
-                F._error('image');
-            };
+				F._error( 'image' );
+			};
 
-            img.src = F.coming.href;
+			img.src = F.coming.href;
 
-            if (img.complete !== true) {
-                F.showLoading();
-            }
-        },
+			if (img.complete !== true) {
+				F.showLoading();
+			}
+		},
 
-        _loadAjax: function () {
-            var coming = F.coming;
+		_loadAjax: function () {
+			var coming = F.coming;
 
-            F.showLoading();
+			F.showLoading();
 
-            F.ajaxLoad = $.ajax($.extend({}, coming.ajax, {
-                url: coming.href,
-                error: function (jqXHR, textStatus) {
-                    if (F.coming && textStatus !== 'abort') {
-                        F._error('ajax', jqXHR);
+			F.ajaxLoad = $.ajax($.extend({}, coming.ajax, {
+				url: coming.href,
+				error: function (jqXHR, textStatus) {
+					if (F.coming && textStatus !== 'abort') {
+						F._error( 'ajax', jqXHR );
 
-                    } else {
-                        F.hideLoading();
-                    }
-                },
-                success: function (data, textStatus) {
-                    if (textStatus === 'success') {
-                        coming.content = data;
+					} else {
+						F.hideLoading();
+					}
+				},
+				success: function (data, textStatus) {
+					if (textStatus === 'success') {
+						coming.content = data;
 
-                        F._afterLoad();
-                    }
-                }
-            }));
-        },
+						F._afterLoad();
+					}
+				}
+			}));
+		},
 
-        _loadIframe: function () {
-            var coming = F.coming,
+		_loadIframe: function() {
+			var coming = F.coming,
 				iframe = $(coming.tpl.iframe.replace(/\{rnd\}/g, new Date().getTime()))
 					.attr('scrolling', isTouch ? 'auto' : coming.iframe.scrolling)
 					.attr('src', coming.href);
 
-            // This helps IE
-            $(coming.wrap).bind('onReset', function () {
-                try {
-                    $(this).find('iframe').hide().attr('src', '//about:blank').end().empty();
-                } catch (e) { }
-            });
+			// This helps IE
+			$(coming.wrap).bind('onReset', function () {
+				try {
+					$(this).find('iframe').hide().attr('src', '//about:blank').end().empty();
+				} catch (e) {}
+			});
 
-            if (coming.iframe.preload) {
-                F.showLoading();
+			if (coming.iframe.preload) {
+				F.showLoading();
 
-                iframe.one('load', function () {
-                    $(this).data('ready', 1);
+				iframe.one('load', function() {
+					$(this).data('ready', 1);
 
-                    // iOS will lose scrolling if we resize
-                    if (!isTouch) {
-                        $(this).bind('load.fb', F.update);
-                    }
+					// iOS will lose scrolling if we resize
+					if (!isTouch) {
+						$(this).bind('load.fb', F.update);
+					}
 
-                    // Without this trick:
-                    //   - iframe won't scroll on iOS devices
-                    //   - IE7 sometimes displays empty iframe
-                    $(this).parents('.fancybox-wrap').width('100%').removeClass('fancybox-tmp').show();
+					// Without this trick:
+					//   - iframe won't scroll on iOS devices
+					//   - IE7 sometimes displays empty iframe
+					$(this).parents('.fancybox-wrap').width('100%').removeClass('fancybox-tmp').show();
 
-                    F._afterLoad();
-                });
-            }
+					F._afterLoad();
+				});
+			}
 
-            coming.content = iframe.appendTo(coming.inner);
+			coming.content = iframe.appendTo( coming.inner );
 
-            if (!coming.iframe.preload) {
-                F._afterLoad();
-            }
-        },
+			if (!coming.iframe.preload) {
+				F._afterLoad();
+			}
+		},
 
-        _preloadImages: function () {
-            var group = F.group,
+		_preloadImages: function() {
+			var group   = F.group,
 				current = F.current,
-				len = group.length,
-				cnt = current.preload ? Math.min(current.preload, len - 1) : 0,
+				len     = group.length,
+				cnt     = current.preload ? Math.min(current.preload, len - 1) : 0,
 				item,
 				i;
 
-            for (i = 1; i <= cnt; i += 1) {
-                item = group[(current.index + i) % len];
+			for (i = 1; i <= cnt; i += 1) {
+				item = group[ (current.index + i ) % len ];
 
-                if (item.type === 'image' && item.href) {
-                    new Image().src = item.href;
-                }
-            }
-        },
+				if (item.type === 'image' && item.href) {
+					new Image().src = item.href;
+				}
+			}
+		},
 
-        _afterLoad: function () {
-            var coming = F.coming,
+		_afterLoad: function () {
+			var coming   = F.coming,
 				previous = F.current,
 				placeholder = 'fancybox-placeholder',
 				current,
@@ -6208,137 +6208,137 @@ var fakewaffle = (function ($, fakewaffle) {
 				href,
 				embed;
 
-            F.hideLoading();
+			F.hideLoading();
 
-            if (!coming || F.isActive === false) {
-                return;
-            }
+			if (!coming || F.isActive === false) {
+				return;
+			}
 
-            if (false === F.trigger('afterLoad', coming, previous)) {
-                coming.wrap.stop(true).trigger('onReset').remove();
+			if (false === F.trigger('afterLoad', coming, previous)) {
+				coming.wrap.stop(true).trigger('onReset').remove();
 
-                F.coming = null;
+				F.coming = null;
 
-                return;
-            }
+				return;
+			}
 
-            if (previous) {
-                F.trigger('beforeChange', previous);
+			if (previous) {
+				F.trigger('beforeChange', previous);
 
-                previous.wrap.stop(true).removeClass('fancybox-opened')
+				previous.wrap.stop(true).removeClass('fancybox-opened')
 					.find('.fancybox-item, .fancybox-nav')
 					.remove();
-            }
+			}
 
-            F.unbindEvents();
+			F.unbindEvents();
 
-            current = coming;
-            content = coming.content;
-            type = coming.type;
-            scrolling = coming.scrolling;
+			current   = coming;
+			content   = coming.content;
+			type      = coming.type;
+			scrolling = coming.scrolling;
 
-            $.extend(F, {
-                wrap: current.wrap,
-                skin: current.skin,
-                outer: current.outer,
-                inner: current.inner,
-                current: current,
-                previous: previous
-            });
+			$.extend(F, {
+				wrap  : current.wrap,
+				skin  : current.skin,
+				outer : current.outer,
+				inner : current.inner,
+				current  : current,
+				previous : previous
+			});
 
-            href = current.href;
+			href = current.href;
 
-            switch (type) {
-                case 'inline':
-                case 'ajax':
-                case 'html':
-                    if (current.selector) {
-                        content = $('<div>').html(content).find(current.selector);
+			switch (type) {
+				case 'inline':
+				case 'ajax':
+				case 'html':
+					if (current.selector) {
+						content = $('<div>').html(content).find(current.selector);
 
-                    } else if (isQuery(content)) {
-                        if (!content.data(placeholder)) {
-                            content.data(placeholder, $('<div class="' + placeholder + '"></div>').insertAfter(content).hide());
-                        }
+					} else if (isQuery(content)) {
+						if (!content.data(placeholder)) {
+							content.data(placeholder, $('<div class="' + placeholder + '"></div>').insertAfter( content ).hide() );
+						}
 
-                        content = content.show().detach();
+						content = content.show().detach();
 
-                        current.wrap.bind('onReset', function () {
-                            if ($(this).find(content).length) {
-                                content.hide().replaceAll(content.data(placeholder)).data(placeholder, false);
-                            }
-                        });
-                    }
-                    break;
+						current.wrap.bind('onReset', function () {
+							if ($(this).find(content).length) {
+								content.hide().replaceAll( content.data(placeholder) ).data(placeholder, false);
+							}
+						});
+					}
+				break;
 
-                case 'image':
-                    content = current.tpl.image.replace(/\{href\}/g, href);
-                    break;
+				case 'image':
+					content = current.tpl.image.replace(/\{href\}/g, href);
+				break;
 
-                case 'swf':
-                    content = '<object id="fancybox-swf" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="100%" height="100%"><param name="movie" value="' + href + '"></param>';
-                    embed = '';
+				case 'swf':
+					content = '<object id="fancybox-swf" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="100%" height="100%"><param name="movie" value="' + href + '"></param>';
+					embed   = '';
 
-                    $.each(current.swf, function (name, val) {
-                        content += '<param name="' + name + '" value="' + val + '"></param>';
-                        embed += ' ' + name + '="' + val + '"';
-                    });
+					$.each(current.swf, function(name, val) {
+						content += '<param name="' + name + '" value="' + val + '"></param>';
+						embed   += ' ' + name + '="' + val + '"';
+					});
 
-                    content += '<embed src="' + href + '" type="application/x-shockwave-flash" width="100%" height="100%"' + embed + '></embed></object>';
-                    break;
-            }
+					content += '<embed src="' + href + '" type="application/x-shockwave-flash" width="100%" height="100%"' + embed + '></embed></object>';
+				break;
+			}
 
-            if (!(isQuery(content) && content.parent().is(current.inner))) {
-                current.inner.append(content);
-            }
+			if (!(isQuery(content) && content.parent().is(current.inner))) {
+				current.inner.append( content );
+			}
 
-            // Give a chance for helpers or callbacks to update elements
-            F.trigger('beforeShow');
+			// Give a chance for helpers or callbacks to update elements
+			F.trigger('beforeShow');
 
-            // Set scrolling before calculating dimensions
-            current.inner.css('overflow', scrolling === 'yes' ? 'scroll' : (scrolling === 'no' ? 'hidden' : scrolling));
+			// Set scrolling before calculating dimensions
+			current.inner.css('overflow', scrolling === 'yes' ? 'scroll' : (scrolling === 'no' ? 'hidden' : scrolling));
 
-            // Set initial dimensions and start position
-            F._setDimension();
+			// Set initial dimensions and start position
+			F._setDimension();
 
-            F.reposition();
+			F.reposition();
 
-            F.isOpen = false;
-            F.coming = null;
+			F.isOpen = false;
+			F.coming = null;
 
-            F.bindEvents();
+			F.bindEvents();
 
-            if (!F.isOpened) {
-                $('.fancybox-wrap').not(current.wrap).stop(true).trigger('onReset').remove();
+			if (!F.isOpened) {
+				$('.fancybox-wrap').not( current.wrap ).stop(true).trigger('onReset').remove();
 
-            } else if (previous.prevMethod) {
-                F.transitions[previous.prevMethod]();
-            }
+			} else if (previous.prevMethod) {
+				F.transitions[ previous.prevMethod ]();
+			}
 
-            F.transitions[F.isOpened ? current.nextMethod : current.openMethod]();
+			F.transitions[ F.isOpened ? current.nextMethod : current.openMethod ]();
 
-            F._preloadImages();
-        },
+			F._preloadImages();
+		},
 
-        _setDimension: function () {
-            var viewport = F.getViewport(),
-				steps = 0,
-				canShrink = false,
-				canExpand = false,
-				wrap = F.wrap,
-				skin = F.skin,
-				inner = F.inner,
-				current = F.current,
-				width = current.width,
-				height = current.height,
-				minWidth = current.minWidth,
-				minHeight = current.minHeight,
-				maxWidth = current.maxWidth,
-				maxHeight = current.maxHeight,
-				scrolling = current.scrolling,
-				scrollOut = current.scrollOutside ? current.scrollbarWidth : 0,
-				margin = current.margin,
-				wMargin = getScalar(margin[1] + margin[3]),
-				hMargin = getScalar(margin[0] + margin[2]),
+		_setDimension: function () {
+			var viewport   = F.getViewport(),
+				steps      = 0,
+				canShrink  = false,
+				canExpand  = false,
+				wrap       = F.wrap,
+				skin       = F.skin,
+				inner      = F.inner,
+				current    = F.current,
+				width      = current.width,
+				height     = current.height,
+				minWidth   = current.minWidth,
+				minHeight  = current.minHeight,
+				maxWidth   = current.maxWidth,
+				maxHeight  = current.maxHeight,
+				scrolling  = current.scrolling,
+				scrollOut  = current.scrollOutside ? current.scrollbarWidth : 0,
+				margin     = current.margin,
+				wMargin    = getScalar(margin[1] + margin[3]),
+				hMargin    = getScalar(margin[0] + margin[2]),
 				wPadding,
 				hPadding,
 				wSpace,
@@ -6355,814 +6355,814 @@ var fakewaffle = (function ($, fakewaffle) {
 				iframe,
 				body;
 
-            // Reset dimensions so we could re-check actual size
-            wrap.add(skin).add(inner).width('auto').height('auto').removeClass('fancybox-tmp');
+			// Reset dimensions so we could re-check actual size
+			wrap.add(skin).add(inner).width('auto').height('auto').removeClass('fancybox-tmp');
 
-            wPadding = getScalar(skin.outerWidth(true) - skin.width());
-            hPadding = getScalar(skin.outerHeight(true) - skin.height());
+			wPadding = getScalar(skin.outerWidth(true)  - skin.width());
+			hPadding = getScalar(skin.outerHeight(true) - skin.height());
 
-            // Any space between content and viewport (margin, padding, border, title)
-            wSpace = wMargin + wPadding;
-            hSpace = hMargin + hPadding;
+			// Any space between content and viewport (margin, padding, border, title)
+			wSpace = wMargin + wPadding;
+			hSpace = hMargin + hPadding;
 
-            origWidth = isPercentage(width) ? (viewport.w - wSpace) * getScalar(width) / 100 : width;
-            origHeight = isPercentage(height) ? (viewport.h - hSpace) * getScalar(height) / 100 : height;
+			origWidth  = isPercentage(width)  ? (viewport.w - wSpace) * getScalar(width)  / 100 : width;
+			origHeight = isPercentage(height) ? (viewport.h - hSpace) * getScalar(height) / 100 : height;
 
-            if (current.type === 'iframe') {
-                iframe = current.content;
+			if (current.type === 'iframe') {
+				iframe = current.content;
 
-                if (current.autoHeight && iframe.data('ready') === 1) {
-                    try {
-                        if (iframe[0].contentWindow.document.location) {
-                            inner.width(origWidth).height(9999);
+				if (current.autoHeight && iframe.data('ready') === 1) {
+					try {
+						if (iframe[0].contentWindow.document.location) {
+							inner.width( origWidth ).height(9999);
 
-                            body = iframe.contents().find('body');
+							body = iframe.contents().find('body');
 
-                            if (scrollOut) {
-                                body.css('overflow-x', 'hidden');
-                            }
+							if (scrollOut) {
+								body.css('overflow-x', 'hidden');
+							}
 
-                            origHeight = body.outerHeight(true);
-                        }
+							origHeight = body.outerHeight(true);
+						}
 
-                    } catch (e) { }
-                }
+					} catch (e) {}
+				}
 
-            } else if (current.autoWidth || current.autoHeight) {
-                inner.addClass('fancybox-tmp');
+			} else if (current.autoWidth || current.autoHeight) {
+				inner.addClass( 'fancybox-tmp' );
 
-                // Set width or height in case we need to calculate only one dimension
-                if (!current.autoWidth) {
-                    inner.width(origWidth);
-                }
+				// Set width or height in case we need to calculate only one dimension
+				if (!current.autoWidth) {
+					inner.width( origWidth );
+				}
 
-                if (!current.autoHeight) {
-                    inner.height(origHeight);
-                }
+				if (!current.autoHeight) {
+					inner.height( origHeight );
+				}
 
-                if (current.autoWidth) {
-                    origWidth = inner.width();
-                }
+				if (current.autoWidth) {
+					origWidth = inner.width();
+				}
 
-                if (current.autoHeight) {
-                    origHeight = inner.height();
-                }
+				if (current.autoHeight) {
+					origHeight = inner.height();
+				}
 
-                inner.removeClass('fancybox-tmp');
-            }
+				inner.removeClass( 'fancybox-tmp' );
+			}
 
-            width = getScalar(origWidth);
-            height = getScalar(origHeight);
+			width  = getScalar( origWidth );
+			height = getScalar( origHeight );
 
-            ratio = origWidth / origHeight;
+			ratio  = origWidth / origHeight;
 
-            // Calculations for the content
-            minWidth = getScalar(isPercentage(minWidth) ? getScalar(minWidth, 'w') - wSpace : minWidth);
-            maxWidth = getScalar(isPercentage(maxWidth) ? getScalar(maxWidth, 'w') - wSpace : maxWidth);
+			// Calculations for the content
+			minWidth  = getScalar(isPercentage(minWidth) ? getScalar(minWidth, 'w') - wSpace : minWidth);
+			maxWidth  = getScalar(isPercentage(maxWidth) ? getScalar(maxWidth, 'w') - wSpace : maxWidth);
 
-            minHeight = getScalar(isPercentage(minHeight) ? getScalar(minHeight, 'h') - hSpace : minHeight);
-            maxHeight = getScalar(isPercentage(maxHeight) ? getScalar(maxHeight, 'h') - hSpace : maxHeight);
+			minHeight = getScalar(isPercentage(minHeight) ? getScalar(minHeight, 'h') - hSpace : minHeight);
+			maxHeight = getScalar(isPercentage(maxHeight) ? getScalar(maxHeight, 'h') - hSpace : maxHeight);
 
-            // These will be used to determine if wrap can fit in the viewport
-            origMaxWidth = maxWidth;
-            origMaxHeight = maxHeight;
+			// These will be used to determine if wrap can fit in the viewport
+			origMaxWidth  = maxWidth;
+			origMaxHeight = maxHeight;
 
-            if (current.fitToView) {
-                maxWidth = Math.min(viewport.w - wSpace, maxWidth);
-                maxHeight = Math.min(viewport.h - hSpace, maxHeight);
-            }
+			if (current.fitToView) {
+				maxWidth  = Math.min(viewport.w - wSpace, maxWidth);
+				maxHeight = Math.min(viewport.h - hSpace, maxHeight);
+			}
 
-            maxWidth_ = viewport.w - wMargin;
-            maxHeight_ = viewport.h - hMargin;
+			maxWidth_  = viewport.w - wMargin;
+			maxHeight_ = viewport.h - hMargin;
 
-            if (current.aspectRatio) {
-                if (width > maxWidth) {
-                    width = maxWidth;
-                    height = getScalar(width / ratio);
-                }
+			if (current.aspectRatio) {
+				if (width > maxWidth) {
+					width  = maxWidth;
+					height = getScalar(width / ratio);
+				}
 
-                if (height > maxHeight) {
-                    height = maxHeight;
-                    width = getScalar(height * ratio);
-                }
+				if (height > maxHeight) {
+					height = maxHeight;
+					width  = getScalar(height * ratio);
+				}
 
-                if (width < minWidth) {
-                    width = minWidth;
-                    height = getScalar(width / ratio);
-                }
+				if (width < minWidth) {
+					width  = minWidth;
+					height = getScalar(width / ratio);
+				}
 
-                if (height < minHeight) {
-                    height = minHeight;
-                    width = getScalar(height * ratio);
-                }
+				if (height < minHeight) {
+					height = minHeight;
+					width  = getScalar(height * ratio);
+				}
 
-            } else {
-                width = Math.max(minWidth, Math.min(width, maxWidth));
+			} else {
+				width = Math.max(minWidth, Math.min(width, maxWidth));
 
-                if (current.autoHeight && current.type !== 'iframe') {
-                    inner.width(width);
+				if (current.autoHeight && current.type !== 'iframe') {
+					inner.width( width );
 
-                    height = inner.height();
-                }
+					height = inner.height();
+				}
 
-                height = Math.max(minHeight, Math.min(height, maxHeight));
-            }
+				height = Math.max(minHeight, Math.min(height, maxHeight));
+			}
 
-            // Try to fit inside viewport (including the title)
-            if (current.fitToView) {
-                inner.width(width).height(height);
+			// Try to fit inside viewport (including the title)
+			if (current.fitToView) {
+				inner.width( width ).height( height );
 
-                wrap.width(width + wPadding);
+				wrap.width( width + wPadding );
 
-                // Real wrap dimensions
-                width_ = wrap.width();
-                height_ = wrap.height();
+				// Real wrap dimensions
+				width_  = wrap.width();
+				height_ = wrap.height();
 
-                if (current.aspectRatio) {
-                    while ((width_ > maxWidth_ || height_ > maxHeight_) && width > minWidth && height > minHeight) {
-                        if (steps++ > 19) {
-                            break;
-                        }
+				if (current.aspectRatio) {
+					while ((width_ > maxWidth_ || height_ > maxHeight_) && width > minWidth && height > minHeight) {
+						if (steps++ > 19) {
+							break;
+						}
 
-                        height = Math.max(minHeight, Math.min(maxHeight, height - 10));
-                        width = getScalar(height * ratio);
+						height = Math.max(minHeight, Math.min(maxHeight, height - 10));
+						width  = getScalar(height * ratio);
 
-                        if (width < minWidth) {
-                            width = minWidth;
-                            height = getScalar(width / ratio);
-                        }
+						if (width < minWidth) {
+							width  = minWidth;
+							height = getScalar(width / ratio);
+						}
 
-                        if (width > maxWidth) {
-                            width = maxWidth;
-                            height = getScalar(width / ratio);
-                        }
+						if (width > maxWidth) {
+							width  = maxWidth;
+							height = getScalar(width / ratio);
+						}
 
-                        inner.width(width).height(height);
+						inner.width( width ).height( height );
 
-                        wrap.width(width + wPadding);
+						wrap.width( width + wPadding );
 
-                        width_ = wrap.width();
-                        height_ = wrap.height();
-                    }
+						width_  = wrap.width();
+						height_ = wrap.height();
+					}
 
-                } else {
-                    width = Math.max(minWidth, Math.min(width, width - (width_ - maxWidth_)));
-                    height = Math.max(minHeight, Math.min(height, height - (height_ - maxHeight_)));
-                }
-            }
+				} else {
+					width  = Math.max(minWidth,  Math.min(width,  width  - (width_  - maxWidth_)));
+					height = Math.max(minHeight, Math.min(height, height - (height_ - maxHeight_)));
+				}
+			}
 
-            if (scrollOut && scrolling === 'auto' && height < origHeight && (width + wPadding + scrollOut) < maxWidth_) {
-                width += scrollOut;
-            }
+			if (scrollOut && scrolling === 'auto' && height < origHeight && (width + wPadding + scrollOut) < maxWidth_) {
+				width += scrollOut;
+			}
 
-            inner.width(width).height(height);
+			inner.width( width ).height( height );
 
-            wrap.width(width + wPadding);
+			wrap.width( width + wPadding );
 
-            width_ = wrap.width();
-            height_ = wrap.height();
+			width_  = wrap.width();
+			height_ = wrap.height();
 
-            canShrink = (width_ > maxWidth_ || height_ > maxHeight_) && width > minWidth && height > minHeight;
-            canExpand = current.aspectRatio ? (width < origMaxWidth && height < origMaxHeight && width < origWidth && height < origHeight) : ((width < origMaxWidth || height < origMaxHeight) && (width < origWidth || height < origHeight));
+			canShrink = (width_ > maxWidth_ || height_ > maxHeight_) && width > minWidth && height > minHeight;
+			canExpand = current.aspectRatio ? (width < origMaxWidth && height < origMaxHeight && width < origWidth && height < origHeight) : ((width < origMaxWidth || height < origMaxHeight) && (width < origWidth || height < origHeight));
 
-            $.extend(current, {
-                dim: {
-                    width: getValue(width_),
-                    height: getValue(height_)
-                },
-                origWidth: origWidth,
-                origHeight: origHeight,
-                canShrink: canShrink,
-                canExpand: canExpand,
-                wPadding: wPadding,
-                hPadding: hPadding,
-                wrapSpace: height_ - skin.outerHeight(true),
-                skinSpace: skin.height() - height
-            });
+			$.extend(current, {
+				dim : {
+					width	: getValue( width_ ),
+					height	: getValue( height_ )
+				},
+				origWidth  : origWidth,
+				origHeight : origHeight,
+				canShrink  : canShrink,
+				canExpand  : canExpand,
+				wPadding   : wPadding,
+				hPadding   : hPadding,
+				wrapSpace  : height_ - skin.outerHeight(true),
+				skinSpace  : skin.height() - height
+			});
 
-            if (!iframe && current.autoHeight && height > minHeight && height < maxHeight && !canExpand) {
-                inner.height('auto');
-            }
-        },
+			if (!iframe && current.autoHeight && height > minHeight && height < maxHeight && !canExpand) {
+				inner.height('auto');
+			}
+		},
 
-        _getPosition: function (onlyAbsolute) {
-            var current = F.current,
+		_getPosition: function (onlyAbsolute) {
+			var current  = F.current,
 				viewport = F.getViewport(),
-				margin = current.margin,
-				width = F.wrap.width() + margin[1] + margin[3],
-				height = F.wrap.height() + margin[0] + margin[2],
-				rez = {
-				    position: 'absolute',
-				    top: margin[0],
-				    left: margin[3]
+				margin   = current.margin,
+				width    = F.wrap.width()  + margin[1] + margin[3],
+				height   = F.wrap.height() + margin[0] + margin[2],
+				rez      = {
+					position: 'absolute',
+					top  : margin[0],
+					left : margin[3]
 				};
 
-            if (current.autoCenter && current.fixed && !onlyAbsolute && height <= viewport.h && width <= viewport.w) {
-                rez.position = 'fixed';
+			if (current.autoCenter && current.fixed && !onlyAbsolute && height <= viewport.h && width <= viewport.w) {
+				rez.position = 'fixed';
 
-            } else if (!current.locked) {
-                rez.top += viewport.y;
-                rez.left += viewport.x;
-            }
+			} else if (!current.locked) {
+				rez.top  += viewport.y;
+				rez.left += viewport.x;
+			}
 
-            rez.top = getValue(Math.max(rez.top, rez.top + ((viewport.h - height) * current.topRatio)));
-            rez.left = getValue(Math.max(rez.left, rez.left + ((viewport.w - width) * current.leftRatio)));
+			rez.top  = getValue(Math.max(rez.top,  rez.top  + ((viewport.h - height) * current.topRatio)));
+			rez.left = getValue(Math.max(rez.left, rez.left + ((viewport.w - width)  * current.leftRatio)));
 
-            return rez;
-        },
+			return rez;
+		},
 
-        _afterZoomIn: function () {
-            var current = F.current;
+		_afterZoomIn: function () {
+			var current = F.current;
 
-            if (!current) {
-                return;
-            }
+			if (!current) {
+				return;
+			}
 
-            F.isOpen = F.isOpened = true;
+			F.isOpen = F.isOpened = true;
 
-            F.wrap.css('overflow', 'visible').addClass('fancybox-opened').hide().show(0);
+			F.wrap.css('overflow', 'visible').addClass('fancybox-opened').hide().show(0);
 
-            F.update();
+			F.update();
 
-            // Assign a click event
-            if (current.closeClick || (current.nextClick && F.group.length > 1)) {
-                F.inner.css('cursor', 'pointer').bind('click.fb', function (e) {
-                    if (!$(e.target).is('a') && !$(e.target).parent().is('a')) {
-                        e.preventDefault();
+			// Assign a click event
+			if ( current.closeClick || (current.nextClick && F.group.length > 1) ) {
+				F.inner.css('cursor', 'pointer').bind('click.fb', function(e) {
+					if (!$(e.target).is('a') && !$(e.target).parent().is('a')) {
+						e.preventDefault();
 
-                        F[current.closeClick ? 'close' : 'next']();
-                    }
-                });
-            }
+						F[ current.closeClick ? 'close' : 'next' ]();
+					}
+				});
+			}
 
-            // Create a close button
-            if (current.closeBtn) {
-                $(current.tpl.closeBtn).appendTo(F.skin).bind('click.fb', function (e) {
-                    e.preventDefault();
+			// Create a close button
+			if (current.closeBtn) {
+				$(current.tpl.closeBtn).appendTo(F.skin).bind('click.fb', function(e) {
+					e.preventDefault();
 
-                    F.close();
-                });
-            }
+					F.close();
+				});
+			}
 
-            // Create navigation arrows
-            if (current.arrows && F.group.length > 1) {
-                if (current.loop || current.index > 0) {
-                    $(current.tpl.prev).appendTo(F.outer).bind('click.fb', F.prev);
-                }
+			// Create navigation arrows
+			if (current.arrows && F.group.length > 1) {
+				if (current.loop || current.index > 0) {
+					$(current.tpl.prev).appendTo(F.outer).bind('click.fb', F.prev);
+				}
 
-                if (current.loop || current.index < F.group.length - 1) {
-                    $(current.tpl.next).appendTo(F.outer).bind('click.fb', F.next);
-                }
-            }
+				if (current.loop || current.index < F.group.length - 1) {
+					$(current.tpl.next).appendTo(F.outer).bind('click.fb', F.next);
+				}
+			}
 
-            F.trigger('afterShow');
+			F.trigger('afterShow');
 
-            // Stop the slideshow if this is the last item
-            if (!current.loop && current.index === current.group.length - 1) {
+			// Stop the slideshow if this is the last item
+			if (!current.loop && current.index === current.group.length - 1) {
 
-                F.play(false);
+				F.play( false );
 
-            } else if (F.opts.autoPlay && !F.player.isActive) {
-                F.opts.autoPlay = false;
+			} else if (F.opts.autoPlay && !F.player.isActive) {
+				F.opts.autoPlay = false;
 
-                F.play(true);
-            }
-        },
+				F.play(true);
+			}
+		},
 
-        _afterZoomOut: function (obj) {
-            obj = obj || F.current;
+		_afterZoomOut: function ( obj ) {
+			obj = obj || F.current;
 
-            $('.fancybox-wrap').trigger('onReset').remove();
+			$('.fancybox-wrap').trigger('onReset').remove();
 
-            $.extend(F, {
-                group: {},
-                opts: {},
-                router: false,
-                current: null,
-                isActive: false,
-                isOpened: false,
-                isOpen: false,
-                isClosing: false,
-                wrap: null,
-                skin: null,
-                outer: null,
-                inner: null
-            });
+			$.extend(F, {
+				group  : {},
+				opts   : {},
+				router : false,
+				current   : null,
+				isActive  : false,
+				isOpened  : false,
+				isOpen    : false,
+				isClosing : false,
+				wrap   : null,
+				skin   : null,
+				outer  : null,
+				inner  : null
+			});
 
-            F.trigger('afterClose', obj);
-        }
-    });
+			F.trigger('afterClose', obj);
+		}
+	});
 
-    /*
+	/*
 	 *	Default transitions
 	 */
 
-    F.transitions = {
-        getOrigPosition: function () {
-            var current = F.current,
-				element = current.element,
-				orig = current.orig,
-				pos = {},
-				width = 50,
-				height = 50,
+	F.transitions = {
+		getOrigPosition: function () {
+			var current  = F.current,
+				element  = current.element,
+				orig     = current.orig,
+				pos      = {},
+				width    = 50,
+				height   = 50,
 				hPadding = current.hPadding,
 				wPadding = current.wPadding,
 				viewport = F.getViewport();
 
-            if (!orig && current.isDom && element.is(':visible')) {
-                orig = element.find('img:first');
+			if (!orig && current.isDom && element.is(':visible')) {
+				orig = element.find('img:first');
 
-                if (!orig.length) {
-                    orig = element;
-                }
-            }
+				if (!orig.length) {
+					orig = element;
+				}
+			}
 
-            if (isQuery(orig)) {
-                pos = orig.offset();
+			if (isQuery(orig)) {
+				pos = orig.offset();
 
-                if (orig.is('img')) {
-                    width = orig.outerWidth();
-                    height = orig.outerHeight();
-                }
+				if (orig.is('img')) {
+					width  = orig.outerWidth();
+					height = orig.outerHeight();
+				}
 
-            } else {
-                pos.top = viewport.y + (viewport.h - height) * current.topRatio;
-                pos.left = viewport.x + (viewport.w - width) * current.leftRatio;
-            }
+			} else {
+				pos.top  = viewport.y + (viewport.h - height) * current.topRatio;
+				pos.left = viewport.x + (viewport.w - width)  * current.leftRatio;
+			}
 
-            if (F.wrap.css('position') === 'fixed' || current.locked) {
-                pos.top -= viewport.y;
-                pos.left -= viewport.x;
-            }
+			if (F.wrap.css('position') === 'fixed' || current.locked) {
+				pos.top  -= viewport.y;
+				pos.left -= viewport.x;
+			}
 
-            pos = {
-                top: getValue(pos.top - hPadding * current.topRatio),
-                left: getValue(pos.left - wPadding * current.leftRatio),
-                width: getValue(width + wPadding),
-                height: getValue(height + hPadding)
-            };
+			pos = {
+				top     : getValue(pos.top  - hPadding * current.topRatio),
+				left    : getValue(pos.left - wPadding * current.leftRatio),
+				width   : getValue(width  + wPadding),
+				height  : getValue(height + hPadding)
+			};
 
-            return pos;
-        },
+			return pos;
+		},
 
-        step: function (now, fx) {
-            var ratio,
+		step: function (now, fx) {
+			var ratio,
 				padding,
 				value,
-				prop = fx.prop,
-				current = F.current,
-				wrapSpace = current.wrapSpace,
-				skinSpace = current.skinSpace;
+				prop       = fx.prop,
+				current    = F.current,
+				wrapSpace  = current.wrapSpace,
+				skinSpace  = current.skinSpace;
 
-            if (prop === 'width' || prop === 'height') {
-                ratio = fx.end === fx.start ? 1 : (now - fx.start) / (fx.end - fx.start);
+			if (prop === 'width' || prop === 'height') {
+				ratio = fx.end === fx.start ? 1 : (now - fx.start) / (fx.end - fx.start);
 
-                if (F.isClosing) {
-                    ratio = 1 - ratio;
-                }
+				if (F.isClosing) {
+					ratio = 1 - ratio;
+				}
 
-                padding = prop === 'width' ? current.wPadding : current.hPadding;
-                value = now - padding;
+				padding = prop === 'width' ? current.wPadding : current.hPadding;
+				value   = now - padding;
 
-                F.skin[prop](getScalar(prop === 'width' ? value : value - (wrapSpace * ratio)));
-                F.inner[prop](getScalar(prop === 'width' ? value : value - (wrapSpace * ratio) - (skinSpace * ratio)));
-            }
-        },
+				F.skin[ prop ](  getScalar( prop === 'width' ?  value : value - (wrapSpace * ratio) ) );
+				F.inner[ prop ]( getScalar( prop === 'width' ?  value : value - (wrapSpace * ratio) - (skinSpace * ratio) ) );
+			}
+		},
 
-        zoomIn: function () {
-            var current = F.current,
+		zoomIn: function () {
+			var current  = F.current,
 				startPos = current.pos,
-				effect = current.openEffect,
-				elastic = effect === 'elastic',
-				endPos = $.extend({ opacity: 1 }, startPos);
+				effect   = current.openEffect,
+				elastic  = effect === 'elastic',
+				endPos   = $.extend({opacity : 1}, startPos);
 
-            // Remove "position" property that breaks older IE
-            delete endPos.position;
+			// Remove "position" property that breaks older IE
+			delete endPos.position;
 
-            if (elastic) {
-                startPos = this.getOrigPosition();
+			if (elastic) {
+				startPos = this.getOrigPosition();
 
-                if (current.openOpacity) {
-                    startPos.opacity = 0.1;
-                }
+				if (current.openOpacity) {
+					startPos.opacity = 0.1;
+				}
 
-            } else if (effect === 'fade') {
-                startPos.opacity = 0.1;
-            }
+			} else if (effect === 'fade') {
+				startPos.opacity = 0.1;
+			}
 
-            F.wrap.css(startPos).animate(endPos, {
-                duration: effect === 'none' ? 0 : current.openSpeed,
-                easing: current.openEasing,
-                step: elastic ? this.step : null,
-                complete: F._afterZoomIn
-            });
-        },
+			F.wrap.css(startPos).animate(endPos, {
+				duration : effect === 'none' ? 0 : current.openSpeed,
+				easing   : current.openEasing,
+				step     : elastic ? this.step : null,
+				complete : F._afterZoomIn
+			});
+		},
 
-        zoomOut: function () {
-            var current = F.current,
-				effect = current.closeEffect,
-				elastic = effect === 'elastic',
-				endPos = { opacity: 0.1 };
+		zoomOut: function () {
+			var current  = F.current,
+				effect   = current.closeEffect,
+				elastic  = effect === 'elastic',
+				endPos   = {opacity : 0.1};
 
-            if (elastic) {
-                endPos = this.getOrigPosition();
+			if (elastic) {
+				endPos = this.getOrigPosition();
 
-                if (current.closeOpacity) {
-                    endPos.opacity = 0.1;
-                }
-            }
+				if (current.closeOpacity) {
+					endPos.opacity = 0.1;
+				}
+			}
 
-            F.wrap.animate(endPos, {
-                duration: effect === 'none' ? 0 : current.closeSpeed,
-                easing: current.closeEasing,
-                step: elastic ? this.step : null,
-                complete: F._afterZoomOut
-            });
-        },
+			F.wrap.animate(endPos, {
+				duration : effect === 'none' ? 0 : current.closeSpeed,
+				easing   : current.closeEasing,
+				step     : elastic ? this.step : null,
+				complete : F._afterZoomOut
+			});
+		},
 
-        changeIn: function () {
-            var current = F.current,
-				effect = current.nextEffect,
-				startPos = current.pos,
-				endPos = { opacity: 1 },
+		changeIn: function () {
+			var current   = F.current,
+				effect    = current.nextEffect,
+				startPos  = current.pos,
+				endPos    = { opacity : 1 },
 				direction = F.direction,
-				distance = 200,
+				distance  = 200,
 				field;
 
-            startPos.opacity = 0.1;
+			startPos.opacity = 0.1;
 
-            if (effect === 'elastic') {
-                field = direction === 'down' || direction === 'up' ? 'top' : 'left';
+			if (effect === 'elastic') {
+				field = direction === 'down' || direction === 'up' ? 'top' : 'left';
 
-                if (direction === 'down' || direction === 'right') {
-                    startPos[field] = getValue(getScalar(startPos[field]) - distance);
-                    endPos[field] = '+=' + distance + 'px';
+				if (direction === 'down' || direction === 'right') {
+					startPos[ field ] = getValue(getScalar(startPos[ field ]) - distance);
+					endPos[ field ]   = '+=' + distance + 'px';
 
-                } else {
-                    startPos[field] = getValue(getScalar(startPos[field]) + distance);
-                    endPos[field] = '-=' + distance + 'px';
-                }
-            }
+				} else {
+					startPos[ field ] = getValue(getScalar(startPos[ field ]) + distance);
+					endPos[ field ]   = '-=' + distance + 'px';
+				}
+			}
 
-            // Workaround for http://bugs.jquery.com/ticket/12273
-            if (effect === 'none') {
-                F._afterZoomIn();
+			// Workaround for http://bugs.jquery.com/ticket/12273
+			if (effect === 'none') {
+				F._afterZoomIn();
 
-            } else {
-                F.wrap.css(startPos).animate(endPos, {
-                    duration: current.nextSpeed,
-                    easing: current.nextEasing,
-                    complete: F._afterZoomIn
-                });
-            }
-        },
+			} else {
+				F.wrap.css(startPos).animate(endPos, {
+					duration : current.nextSpeed,
+					easing   : current.nextEasing,
+					complete : F._afterZoomIn
+				});
+			}
+		},
 
-        changeOut: function () {
-            var previous = F.previous,
-				effect = previous.prevEffect,
-				endPos = { opacity: 0.1 },
+		changeOut: function () {
+			var previous  = F.previous,
+				effect    = previous.prevEffect,
+				endPos    = { opacity : 0.1 },
 				direction = F.direction,
-				distance = 200;
+				distance  = 200;
 
-            if (effect === 'elastic') {
-                endPos[direction === 'down' || direction === 'up' ? 'top' : 'left'] = (direction === 'up' || direction === 'left' ? '-' : '+') + '=' + distance + 'px';
-            }
+			if (effect === 'elastic') {
+				endPos[ direction === 'down' || direction === 'up' ? 'top' : 'left' ] = ( direction === 'up' || direction === 'left' ? '-' : '+' ) + '=' + distance + 'px';
+			}
 
-            previous.wrap.animate(endPos, {
-                duration: effect === 'none' ? 0 : previous.prevSpeed,
-                easing: previous.prevEasing,
-                complete: function () {
-                    $(this).trigger('onReset').remove();
-                }
-            });
-        }
-    };
+			previous.wrap.animate(endPos, {
+				duration : effect === 'none' ? 0 : previous.prevSpeed,
+				easing   : previous.prevEasing,
+				complete : function () {
+					$(this).trigger('onReset').remove();
+				}
+			});
+		}
+	};
 
-    /*
+	/*
 	 *	Overlay helper
 	 */
 
-    F.helpers.overlay = {
-        defaults: {
-            closeClick: true,      // if true, fancyBox will be closed when user clicks on the overlay
-            speedOut: 200,       // duration of fadeOut animation
-            showEarly: true,      // indicates if should be opened immediately or wait until the content is ready
-            css: {},        // custom CSS properties
-            locked: !isTouch,  // if true, the content will be locked into overlay
-            fixed: true       // if false, the overlay CSS position property will not be set to "fixed"
-        },
+	F.helpers.overlay = {
+		defaults : {
+			closeClick : true,      // if true, fancyBox will be closed when user clicks on the overlay
+			speedOut   : 200,       // duration of fadeOut animation
+			showEarly  : true,      // indicates if should be opened immediately or wait until the content is ready
+			css        : {},        // custom CSS properties
+			locked     : !isTouch,  // if true, the content will be locked into overlay
+			fixed      : true       // if false, the overlay CSS position property will not be set to "fixed"
+		},
 
-        overlay: null,      // current handle
-        fixed: false,     // indicates if the overlay has position "fixed"
-        el: $('html'), // element that contains "the lock"
+		overlay : null,      // current handle
+		fixed   : false,     // indicates if the overlay has position "fixed"
+		el      : $('html'), // element that contains "the lock"
 
-        // Public methods
-        create: function (opts) {
-            var parent;
+		// Public methods
+		create : function(opts) {
+			var parent;
 
-            opts = $.extend({}, this.defaults, opts);
+			opts = $.extend({}, this.defaults, opts);
 
-            if (this.overlay) {
-                this.close();
-            }
+			if (this.overlay) {
+				this.close();
+			}
 
-            parent = F.coming ? F.coming.parent : opts.parent;
+			parent = F.coming ? F.coming.parent : opts.parent;
 
-            this.overlay = $('<div class="fancybox-overlay"></div>').appendTo(parent && parent.length ? parent : 'body');
-            this.fixed = false;
+			this.overlay = $('<div class="fancybox-overlay"></div>').appendTo( parent && parent.length ? parent : 'body' );
+			this.fixed   = false;
 
-            if (opts.fixed && F.defaults.fixed) {
-                this.overlay.addClass('fancybox-overlay-fixed');
+			if (opts.fixed && F.defaults.fixed) {
+				this.overlay.addClass('fancybox-overlay-fixed');
 
-                this.fixed = true;
-            }
-        },
+				this.fixed = true;
+			}
+		},
 
-        open: function (opts) {
-            var that = this;
+		open : function(opts) {
+			var that = this;
 
-            opts = $.extend({}, this.defaults, opts);
+			opts = $.extend({}, this.defaults, opts);
 
-            if (this.overlay) {
-                this.overlay.unbind('.overlay').width('auto').height('auto');
+			if (this.overlay) {
+				this.overlay.unbind('.overlay').width('auto').height('auto');
 
-            } else {
-                this.create(opts);
-            }
+			} else {
+				this.create(opts);
+			}
 
-            if (!this.fixed) {
-                W.bind('resize.overlay', $.proxy(this.update, this));
+			if (!this.fixed) {
+				W.bind('resize.overlay', $.proxy( this.update, this) );
 
-                this.update();
-            }
+				this.update();
+			}
 
-            if (opts.closeClick) {
-                this.overlay.bind('click.overlay', function (e) {
-                    if ($(e.target).hasClass('fancybox-overlay')) {
-                        if (F.isActive) {
-                            F.close();
-                        } else {
-                            that.close();
-                        }
+			if (opts.closeClick) {
+				this.overlay.bind('click.overlay', function(e) {
+					if ($(e.target).hasClass('fancybox-overlay')) {
+						if (F.isActive) {
+							F.close();
+						} else {
+							that.close();
+						}
 
-                        return false;
-                    }
-                });
-            }
+						return false;
+					}
+				});
+			}
 
-            this.overlay.css(opts.css).show();
-        },
+			this.overlay.css( opts.css ).show();
+		},
 
-        close: function () {
-            W.unbind('resize.overlay');
+		close : function() {
+			W.unbind('resize.overlay');
 
-            if (this.el.hasClass('fancybox-lock')) {
-                $('.fancybox-margin').removeClass('fancybox-margin');
+			if (this.el.hasClass('fancybox-lock')) {
+				$('.fancybox-margin').removeClass('fancybox-margin');
 
-                this.el.removeClass('fancybox-lock');
+				this.el.removeClass('fancybox-lock');
 
-                W.scrollTop(this.scrollV).scrollLeft(this.scrollH);
-            }
+				W.scrollTop( this.scrollV ).scrollLeft( this.scrollH );
+			}
 
-            $('.fancybox-overlay').remove().hide();
+			$('.fancybox-overlay').remove().hide();
 
-            $.extend(this, {
-                overlay: null,
-                fixed: false
-            });
-        },
+			$.extend(this, {
+				overlay : null,
+				fixed   : false
+			});
+		},
 
-        // Private, callbacks
+		// Private, callbacks
 
-        update: function () {
-            var width = '100%', offsetWidth;
+		update : function () {
+			var width = '100%', offsetWidth;
 
-            // Reset width/height so it will not mess
-            this.overlay.width(width).height('100%');
+			// Reset width/height so it will not mess
+			this.overlay.width(width).height('100%');
 
-            // jQuery does not return reliable result for IE
-            if (IE) {
-                offsetWidth = Math.max(document.documentElement.offsetWidth, document.body.offsetWidth);
+			// jQuery does not return reliable result for IE
+			if (IE) {
+				offsetWidth = Math.max(document.documentElement.offsetWidth, document.body.offsetWidth);
 
-                if (D.width() > offsetWidth) {
-                    width = D.width();
-                }
+				if (D.width() > offsetWidth) {
+					width = D.width();
+				}
 
-            } else if (D.width() > W.width()) {
-                width = D.width();
-            }
+			} else if (D.width() > W.width()) {
+				width = D.width();
+			}
 
-            this.overlay.width(width).height(D.height());
-        },
+			this.overlay.width(width).height(D.height());
+		},
 
-        // This is where we can manipulate DOM, because later it would cause iframes to reload
-        onReady: function (opts, obj) {
-            var overlay = this.overlay;
+		// This is where we can manipulate DOM, because later it would cause iframes to reload
+		onReady : function (opts, obj) {
+			var overlay = this.overlay;
 
-            $('.fancybox-overlay').stop(true, true);
+			$('.fancybox-overlay').stop(true, true);
 
-            if (!overlay) {
-                this.create(opts);
-            }
+			if (!overlay) {
+				this.create(opts);
+			}
 
-            if (opts.locked && this.fixed && obj.fixed) {
-                obj.locked = this.overlay.append(obj.wrap);
-                obj.fixed = false;
-            }
+			if (opts.locked && this.fixed && obj.fixed) {
+				obj.locked = this.overlay.append( obj.wrap );
+				obj.fixed  = false;
+			}
 
-            if (opts.showEarly === true) {
-                this.beforeShow.apply(this, arguments);
-            }
-        },
+			if (opts.showEarly === true) {
+				this.beforeShow.apply(this, arguments);
+			}
+		},
 
-        beforeShow: function (opts, obj) {
-            if (obj.locked && !this.el.hasClass('fancybox-lock')) {
-                if (this.fixPosition !== false) {
-                    $('*').filter(function () {
-                        return ($(this).css('position') === 'fixed' && !$(this).hasClass("fancybox-overlay") && !$(this).hasClass("fancybox-wrap"));
-                    }).addClass('fancybox-margin');
-                }
+		beforeShow : function(opts, obj) {
+			if (obj.locked && !this.el.hasClass('fancybox-lock')) {
+				if (this.fixPosition !== false) {
+					$('*').filter(function(){
+						return ($(this).css('position') === 'fixed' && !$(this).hasClass("fancybox-overlay") && !$(this).hasClass("fancybox-wrap") );
+					}).addClass('fancybox-margin');
+				}
 
-                this.el.addClass('fancybox-margin');
+				this.el.addClass('fancybox-margin');
 
-                this.scrollV = W.scrollTop();
-                this.scrollH = W.scrollLeft();
+				this.scrollV = W.scrollTop();
+				this.scrollH = W.scrollLeft();
 
-                this.el.addClass('fancybox-lock');
+				this.el.addClass('fancybox-lock');
 
-                W.scrollTop(this.scrollV).scrollLeft(this.scrollH);
-            }
+				W.scrollTop( this.scrollV ).scrollLeft( this.scrollH );
+			}
 
-            this.open(opts);
-        },
+			this.open(opts);
+		},
 
-        onUpdate: function () {
-            if (!this.fixed) {
-                this.update();
-            }
-        },
+		onUpdate : function() {
+			if (!this.fixed) {
+				this.update();
+			}
+		},
 
-        afterClose: function (opts) {
-            // Remove overlay if exists and fancyBox is not opening
-            // (e.g., it is not being open using afterClose callback)
-            if (this.overlay && !F.coming) {
-                this.overlay.fadeOut(opts.speedOut, $.proxy(this.close, this));
-            }
-        }
-    };
+		afterClose: function (opts) {
+			// Remove overlay if exists and fancyBox is not opening
+			// (e.g., it is not being open using afterClose callback)
+			if (this.overlay && !F.coming) {
+				this.overlay.fadeOut(opts.speedOut, $.proxy( this.close, this ));
+			}
+		}
+	};
 
-    /*
+	/*
 	 *	Title helper
 	 */
 
-    F.helpers.title = {
-        defaults: {
-            type: 'float', // 'float', 'inside', 'outside' or 'over',
-            position: 'bottom' // 'top' or 'bottom'
-        },
+	F.helpers.title = {
+		defaults : {
+			type     : 'float', // 'float', 'inside', 'outside' or 'over',
+			position : 'bottom' // 'top' or 'bottom'
+		},
 
-        beforeShow: function (opts) {
-            var current = F.current,
-				text = current.title,
-				type = opts.type,
+		beforeShow: function (opts) {
+			var current = F.current,
+				text    = current.title,
+				type    = opts.type,
 				title,
 				target;
 
-            if ($.isFunction(text)) {
-                text = text.call(current.element, current);
-            }
+			if ($.isFunction(text)) {
+				text = text.call(current.element, current);
+			}
 
-            if (!isString(text) || $.trim(text) === '') {
-                return;
-            }
+			if (!isString(text) || $.trim(text) === '') {
+				return;
+			}
 
-            title = $('<div class="fancybox-title fancybox-title-' + type + '-wrap">' + text + '</div>');
+			title = $('<div class="fancybox-title fancybox-title-' + type + '-wrap">' + text + '</div>');
 
-            switch (type) {
-                case 'inside':
-                    target = F.skin;
-                    break;
+			switch (type) {
+				case 'inside':
+					target = F.skin;
+				break;
 
-                case 'outside':
-                    target = F.wrap;
-                    break;
+				case 'outside':
+					target = F.wrap;
+				break;
 
-                case 'over':
-                    target = F.inner;
-                    break;
+				case 'over':
+					target = F.inner;
+				break;
 
-                default: // 'float'
-                    target = F.skin;
+				default: // 'float'
+					target = F.skin;
 
-                    title.appendTo('body');
+					title.appendTo('body');
 
-                    if (IE) {
-                        title.width(title.width());
-                    }
+					if (IE) {
+						title.width( title.width() );
+					}
 
-                    title.wrapInner('<span class="child"></span>');
+					title.wrapInner('<span class="child"></span>');
 
-                    //Increase bottom margin so this title will also fit into viewport
-                    F.current.margin[2] += Math.abs(getScalar(title.css('margin-bottom')));
-                    break;
-            }
+					//Increase bottom margin so this title will also fit into viewport
+					F.current.margin[2] += Math.abs( getScalar(title.css('margin-bottom')) );
+				break;
+			}
 
-            title[(opts.position === 'top' ? 'prependTo' : 'appendTo')](target);
-        }
-    };
+			title[ (opts.position === 'top' ? 'prependTo'  : 'appendTo') ](target);
+		}
+	};
 
-    // jQuery plugin initialization
-    $.fn.fancybox = function (options) {
-        var index,
-			that = $(this),
+	// jQuery plugin initialization
+	$.fn.fancybox = function (options) {
+		var index,
+			that     = $(this),
 			selector = this.selector || '',
-			run = function (e) {
-			    var what = $(this).blur(), idx = index, relType, relVal;
+			run      = function(e) {
+				var what = $(this).blur(), idx = index, relType, relVal;
 
-			    if (!(e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) && !what.is('.fancybox-wrap')) {
-			        relType = options.groupAttr || 'data-fancybox-group';
-			        relVal = what.attr(relType);
+				if (!(e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) && !what.is('.fancybox-wrap')) {
+					relType = options.groupAttr || 'data-fancybox-group';
+					relVal  = what.attr(relType);
 
-			        if (!relVal) {
-			            relType = 'rel';
-			            relVal = what.get(0)[relType];
-			        }
+					if (!relVal) {
+						relType = 'rel';
+						relVal  = what.get(0)[ relType ];
+					}
 
-			        if (relVal && relVal !== '' && relVal !== 'nofollow') {
-			            what = selector.length ? $(selector) : that;
-			            what = what.filter('[' + relType + '="' + relVal + '"]');
-			            idx = what.index(this);
-			        }
+					if (relVal && relVal !== '' && relVal !== 'nofollow') {
+						what = selector.length ? $(selector) : that;
+						what = what.filter('[' + relType + '="' + relVal + '"]');
+						idx  = what.index(this);
+					}
 
-			        options.index = idx;
+					options.index = idx;
 
-			        // Stop an event from bubbling if everything is fine
-			        if (F.open(what, options) !== false) {
-			            e.preventDefault();
-			        }
-			    }
+					// Stop an event from bubbling if everything is fine
+					if (F.open(what, options) !== false) {
+						e.preventDefault();
+					}
+				}
 			};
 
-        options = options || {};
-        index = options.index || 0;
+		options = options || {};
+		index   = options.index || 0;
 
-        if (!selector || options.live === false) {
-            that.unbind('click.fb-start').bind('click.fb-start', run);
+		if (!selector || options.live === false) {
+			that.unbind('click.fb-start').bind('click.fb-start', run);
 
-        } else {
-            D.undelegate(selector, 'click.fb-start').delegate(selector + ":not('.fancybox-item, .fancybox-nav')", 'click.fb-start', run);
-        }
+		} else {
+			D.undelegate(selector, 'click.fb-start').delegate(selector + ":not('.fancybox-item, .fancybox-nav')", 'click.fb-start', run);
+		}
 
-        this.filter('[data-fancybox-start=1]').trigger('click');
+		this.filter('[data-fancybox-start=1]').trigger('click');
 
-        return this;
-    };
+		return this;
+	};
 
-    // Tests that need a body at doc ready
-    D.ready(function () {
-        var w1, w2;
+	// Tests that need a body at doc ready
+	D.ready(function() {
+		var w1, w2;
 
-        if ($.scrollbarWidth === undefined) {
-            // http://benalman.com/projects/jquery-misc-plugins/#scrollbarwidth
-            $.scrollbarWidth = function () {
-                var parent = $('<div style="width:50px;height:50px;overflow:auto"><div/></div>').appendTo('body'),
-					child = parent.children(),
-					width = child.innerWidth() - child.height(99).innerWidth();
+		if ( $.scrollbarWidth === undefined ) {
+			// http://benalman.com/projects/jquery-misc-plugins/#scrollbarwidth
+			$.scrollbarWidth = function() {
+				var parent = $('<div style="width:50px;height:50px;overflow:auto"><div/></div>').appendTo('body'),
+					child  = parent.children(),
+					width  = child.innerWidth() - child.height( 99 ).innerWidth();
 
-                parent.remove();
+				parent.remove();
 
-                return width;
-            };
-        }
+				return width;
+			};
+		}
 
-        if ($.support.fixedPosition === undefined) {
-            $.support.fixedPosition = (function () {
-                var elem = $('<div style="position:fixed;top:20px;"></div>').appendTo('body'),
-					fixed = (elem[0].offsetTop === 20 || elem[0].offsetTop === 15);
+		if ( $.support.fixedPosition === undefined ) {
+			$.support.fixedPosition = (function() {
+				var elem  = $('<div style="position:fixed;top:20px;"></div>').appendTo('body'),
+					fixed = ( elem[0].offsetTop === 20 || elem[0].offsetTop === 15 );
 
-                elem.remove();
+				elem.remove();
 
-                return fixed;
-            }());
-        }
+				return fixed;
+			}());
+		}
 
-        $.extend(F.defaults, {
-            scrollbarWidth: $.scrollbarWidth(),
-            fixed: $.support.fixedPosition,
-            parent: $('body')
-        });
+		$.extend(F.defaults, {
+			scrollbarWidth : $.scrollbarWidth(),
+			fixed  : $.support.fixedPosition,
+			parent : $('body')
+		});
 
-        //Get real width of page scroll-bar
-        w1 = $(window).width();
+		//Get real width of page scroll-bar
+		w1 = $(window).width();
 
-        H.addClass('fancybox-lock-test');
+		H.addClass('fancybox-lock-test');
 
-        w2 = $(window).width();
+		w2 = $(window).width();
 
-        H.removeClass('fancybox-lock-test');
+		H.removeClass('fancybox-lock-test');
 
-        $("<style type='text/css'>.fancybox-margin{margin-right:" + (w2 - w1) + "px;}</style>").appendTo("head");
-    });
+		$("<style type='text/css'>.fancybox-margin{margin-right:" + (w2 - w1) + "px;}</style>").appendTo("head");
+	});
 
 }(window, document, jQuery));
 
@@ -7178,267 +7178,267 @@ Licensed under GPL v2.
 */
 
 
-(function () {
-    var $;
+(function() {
+  var $;
 
-    $ = jQuery;
+  $ = jQuery;
 
-    $.fn.extend({
-        eqHeight: function (column_selector) {
-            return this.each(function () {
-                var columns, equalizer, _equalize_marked_columns;
-                columns = $(this).find(column_selector);
-                if (columns.length === 0) {
-                    columns = $(this).children(column_selector);
-                }
-                if (columns.length === 0) {
-                    return;
-                }
-                _equalize_marked_columns = function () {
-                    var marked_columns, max_col_height;
-                    marked_columns = $(".eqHeight_row");
-                    max_col_height = 0;
-                    marked_columns.each(function () {
-                        if ($(this).height() > max_col_height) {
-                            return max_col_height = $(this).height();
-                        }
-                    });
-                    marked_columns.height(max_col_height);
-                    return $(".eqHeight_row").removeClass("eqHeight_row");
-                };
-                equalizer = function () {
-                    var row_top_value;
-                    columns.height("auto");
-                    row_top_value = columns.first().position().top;
-                    columns.each(function () {
-                        var current_top;
-                        current_top = $(this).position().top;
-                        if (current_top !== row_top_value) {
-                            _equalize_marked_columns();
-                            row_top_value = $(this).position().top;
-                        }
-                        return $(this).addClass("eqHeight_row");
-                    });
-                    return _equalize_marked_columns();
-                };
-                $(window).load(equalizer);
-                return $(window).resize(equalizer);
-            });
+  $.fn.extend({
+    eqHeight: function(column_selector) {
+      return this.each(function() {
+        var columns, equalizer, _equalize_marked_columns;
+        columns = $(this).find(column_selector);
+        if (columns.length === 0) {
+          columns = $(this).children(column_selector);
         }
-    });
+        if (columns.length === 0) {
+          return;
+        }
+        _equalize_marked_columns = function() {
+          var marked_columns, max_col_height;
+          marked_columns = $(".eqHeight_row");
+          max_col_height = 0;
+          marked_columns.each(function() {
+            if ($(this).height() > max_col_height) {
+              return max_col_height = $(this).height();
+            }
+          });
+          marked_columns.height(max_col_height);
+          return $(".eqHeight_row").removeClass("eqHeight_row");
+        };
+        equalizer = function() {
+          var row_top_value;
+          columns.height("auto");
+          row_top_value = columns.first().position().top;
+          columns.each(function() {
+            var current_top;
+            current_top = $(this).position().top;
+            if (current_top !== row_top_value) {
+              _equalize_marked_columns();
+              row_top_value = $(this).position().top;
+            }
+            return $(this).addClass("eqHeight_row");
+          });
+          return _equalize_marked_columns();
+        };
+        $(window).load(equalizer);
+        return $(window).resize(equalizer);
+      });
+    }
+  });
 
 }).call(this);
 
 
-(function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
-        define(factory);
-    } else if (typeof exports === 'object') {
-        module.exports = factory(require, exports, module);
-    } else {
-        root.CountUp = factory();
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory(require, exports, module);
+  } else {
+    root.CountUp = factory();
+  }
+}(this, function(require, exports, module) {
+
+/*
+
+    countUp.js
+    (c) 2014-2015 @inorganik
+    Licensed under the MIT license.
+
+*/
+
+// target = id of html element or var of previously selected html element where counting occurs
+// startVal = the value you want to begin at
+// endVal = the value you want to arrive at
+// decimals = number of decimal places, default 0
+// duration = duration of animation in seconds, default 2
+// options = optional object of options (see below)
+
+var CountUp = function(target, startVal, endVal, decimals, duration, options) {
+
+    // make sure requestAnimationFrame and cancelAnimationFrame are defined
+    // polyfill for browsers without native support
+    // by Opera engineer Erik Möller
+    var lastTime = 0;
+    var vendors = ['webkit', 'moz', 'ms', 'o'];
+    for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
+        window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
+        window.cancelAnimationFrame =
+          window[vendors[x]+'CancelAnimationFrame'] || window[vendors[x]+'CancelRequestAnimationFrame'];
     }
-}(this, function (require, exports, module) {
+    if (!window.requestAnimationFrame) {
+        window.requestAnimationFrame = function(callback, element) {
+            var currTime = new Date().getTime();
+            var timeToCall = Math.max(0, 16 - (currTime - lastTime));
+            var id = window.setTimeout(function() { callback(currTime + timeToCall); },
+              timeToCall);
+            lastTime = currTime + timeToCall;
+            return id;
+        };
+    }
+    if (!window.cancelAnimationFrame) {
+        window.cancelAnimationFrame = function(id) {
+            clearTimeout(id);
+        };
+    }
 
-    /*
-    
-        countUp.js
-        (c) 2014-2015 @inorganik
-        Licensed under the MIT license.
-    
-    */
-
-    // target = id of html element or var of previously selected html element where counting occurs
-    // startVal = the value you want to begin at
-    // endVal = the value you want to arrive at
-    // decimals = number of decimal places, default 0
-    // duration = duration of animation in seconds, default 2
-    // options = optional object of options (see below)
-
-    var CountUp = function (target, startVal, endVal, decimals, duration, options) {
-
-        // make sure requestAnimationFrame and cancelAnimationFrame are defined
-        // polyfill for browsers without native support
-        // by Opera engineer Erik Möller
-        var lastTime = 0;
-        var vendors = ['webkit', 'moz', 'ms', 'o'];
-        for (var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
-            window.requestAnimationFrame = window[vendors[x] + 'RequestAnimationFrame'];
-            window.cancelAnimationFrame =
-              window[vendors[x] + 'CancelAnimationFrame'] || window[vendors[x] + 'CancelRequestAnimationFrame'];
+     // default options
+    this.options = {
+        useEasing : true, // toggle easing
+        useGrouping : true, // 1,000,000 vs 1000000
+        separator : ',', // character to use as a separator
+        decimal : '.' // character to use as a decimal
+    };
+    // extend default options with passed options object
+    for (var key in options) {
+        if (options.hasOwnProperty(key)) {
+            this.options[key] = options[key];
         }
-        if (!window.requestAnimationFrame) {
-            window.requestAnimationFrame = function (callback, element) {
-                var currTime = new Date().getTime();
-                var timeToCall = Math.max(0, 16 - (currTime - lastTime));
-                var id = window.setTimeout(function () { callback(currTime + timeToCall); },
-                  timeToCall);
-                lastTime = currTime + timeToCall;
-                return id;
-            };
+    }
+    if (this.options.separator === '') this.options.useGrouping = false;
+    if (!this.options.prefix) this.options.prefix = '';
+    if (!this.options.suffix) this.options.suffix = '';
+
+    this.d = (typeof target === 'string') ? document.getElementById(target) : target;
+    this.startVal = Number(startVal);
+    this.endVal = Number(endVal);
+    this.countDown = (this.startVal > this.endVal);
+    this.frameVal = this.startVal;
+    this.decimals = Math.max(0, decimals || 0);
+    this.dec = Math.pow(10, this.decimals);
+    this.duration = Number(duration) * 1000 || 2000;
+    var self = this;
+
+    this.version = function () { return '1.6.0'; };
+
+    // Print value to target
+    this.printValue = function(value) {
+        var result = (!isNaN(value)) ? self.formatNumber(value) : '--';
+        if (self.d.tagName == 'INPUT') {
+            this.d.value = result;
         }
-        if (!window.cancelAnimationFrame) {
-            window.cancelAnimationFrame = function (id) {
-                clearTimeout(id);
-            };
+        else if (self.d.tagName == 'text' || self.d.tagName == 'tspan') {
+            this.d.textContent = result;
         }
-
-        // default options
-        this.options = {
-            useEasing: true, // toggle easing
-            useGrouping: true, // 1,000,000 vs 1000000
-            separator: ',', // character to use as a separator
-            decimal: '.' // character to use as a decimal
-        };
-        // extend default options with passed options object
-        for (var key in options) {
-            if (options.hasOwnProperty(key)) {
-                this.options[key] = options[key];
-            }
+        else {
+            this.d.innerHTML = result;
         }
-        if (this.options.separator === '') this.options.useGrouping = false;
-        if (!this.options.prefix) this.options.prefix = '';
-        if (!this.options.suffix) this.options.suffix = '';
-
-        this.d = (typeof target === 'string') ? document.getElementById(target) : target;
-        this.startVal = Number(startVal);
-        this.endVal = Number(endVal);
-        this.countDown = (this.startVal > this.endVal);
-        this.frameVal = this.startVal;
-        this.decimals = Math.max(0, decimals || 0);
-        this.dec = Math.pow(10, this.decimals);
-        this.duration = Number(duration) * 1000 || 2000;
-        var self = this;
-
-        this.version = function () { return '1.6.0'; };
-
-        // Print value to target
-        this.printValue = function (value) {
-            var result = (!isNaN(value)) ? self.formatNumber(value) : '--';
-            if (self.d.tagName == 'INPUT') {
-                this.d.value = result;
-            }
-            else if (self.d.tagName == 'text' || self.d.tagName == 'tspan') {
-                this.d.textContent = result;
-            }
-            else {
-                this.d.innerHTML = result;
-            }
-        };
-
-        // Robert Penner's easeOutExpo
-        this.easeOutExpo = function (t, b, c, d) {
-            return c * (-Math.pow(2, -10 * t / d) + 1) * 1024 / 1023 + b;
-        };
-        this.count = function (timestamp) {
-
-            if (!self.startTime) self.startTime = timestamp;
-
-            self.timestamp = timestamp;
-
-            var progress = timestamp - self.startTime;
-            self.remaining = self.duration - progress;
-
-            // to ease or not to ease
-            if (self.options.useEasing) {
-                if (self.countDown) {
-                    self.frameVal = self.startVal - self.easeOutExpo(progress, 0, self.startVal - self.endVal, self.duration);
-                } else {
-                    self.frameVal = self.easeOutExpo(progress, self.startVal, self.endVal - self.startVal, self.duration);
-                }
-            } else {
-                if (self.countDown) {
-                    self.frameVal = self.startVal - ((self.startVal - self.endVal) * (progress / self.duration));
-                } else {
-                    self.frameVal = self.startVal + (self.endVal - self.startVal) * (progress / self.duration);
-                }
-            }
-
-            // don't go past endVal since progress can exceed duration in the last frame
-            if (self.countDown) {
-                self.frameVal = (self.frameVal < self.endVal) ? self.endVal : self.frameVal;
-            } else {
-                self.frameVal = (self.frameVal > self.endVal) ? self.endVal : self.frameVal;
-            }
-
-            // decimal
-            self.frameVal = Math.round(self.frameVal * self.dec) / self.dec;
-
-            // format and print value
-            self.printValue(self.frameVal);
-
-            // whether to continue
-            if (progress < self.duration) {
-                self.rAF = requestAnimationFrame(self.count);
-            } else {
-                if (self.callback) self.callback();
-            }
-        };
-        // start your animation
-        this.start = function (callback) {
-            self.callback = callback;
-            self.rAF = requestAnimationFrame(self.count);
-            return false;
-        };
-        // toggles pause/resume animation
-        this.pauseResume = function () {
-            if (!self.paused) {
-                self.paused = true;
-                cancelAnimationFrame(self.rAF);
-            } else {
-                self.paused = false;
-                delete self.startTime;
-                self.duration = self.remaining;
-                self.startVal = self.frameVal;
-                requestAnimationFrame(self.count);
-            }
-        };
-        // reset to startVal so animation can be run again
-        this.reset = function () {
-            self.paused = false;
-            delete self.startTime;
-            self.startVal = startVal;
-            cancelAnimationFrame(self.rAF);
-            self.printValue(self.startVal);
-        };
-        // pass a new endVal and start animation
-        this.update = function (newEndVal) {
-            cancelAnimationFrame(self.rAF);
-            self.paused = false;
-            delete self.startTime;
-            self.startVal = self.frameVal;
-            self.endVal = Number(newEndVal);
-            self.countDown = (self.startVal > self.endVal);
-            self.rAF = requestAnimationFrame(self.count);
-        };
-        this.formatNumber = function (nStr) {
-            nStr = nStr.toFixed(self.decimals);
-            nStr += '';
-            var x, x1, x2, rgx;
-            x = nStr.split('.');
-            x1 = x[0];
-            x2 = x.length > 1 ? self.options.decimal + x[1] : '';
-            rgx = /(\d+)(\d{3})/;
-            if (self.options.useGrouping) {
-                while (rgx.test(x1)) {
-                    x1 = x1.replace(rgx, '$1' + self.options.separator + '$2');
-                }
-            }
-            return self.options.prefix + x1 + x2 + self.options.suffix;
-        };
-
-        // format startVal on initialization
-        self.printValue(self.startVal);
     };
 
-    // Example:
-    // var numAnim = new countUp("SomeElementYouWantToAnimate", 0, 99.99, 2, 2.5);
-    // numAnim.start();
-    // numAnim.update(135);
-    // with optional callback:
-    // numAnim.start(someMethodToCallOnComplete);
+    // Robert Penner's easeOutExpo
+    this.easeOutExpo = function(t, b, c, d) {
+        return c * (-Math.pow(2, -10 * t / d) + 1) * 1024 / 1023 + b;
+    };
+    this.count = function(timestamp) {
 
-    return CountUp;
+        if (!self.startTime) self.startTime = timestamp;
+
+        self.timestamp = timestamp;
+
+        var progress = timestamp - self.startTime;
+        self.remaining = self.duration - progress;
+
+        // to ease or not to ease
+        if (self.options.useEasing) {
+            if (self.countDown) {
+                self.frameVal = self.startVal - self.easeOutExpo(progress, 0, self.startVal - self.endVal, self.duration);
+            } else {
+                self.frameVal = self.easeOutExpo(progress, self.startVal, self.endVal - self.startVal, self.duration);
+            }
+        } else {
+            if (self.countDown) {
+                self.frameVal = self.startVal - ((self.startVal - self.endVal) * (progress / self.duration));
+            } else {
+                self.frameVal = self.startVal + (self.endVal - self.startVal) * (progress / self.duration);
+            }
+        }
+
+        // don't go past endVal since progress can exceed duration in the last frame
+        if (self.countDown) {
+            self.frameVal = (self.frameVal < self.endVal) ? self.endVal : self.frameVal;
+        } else {
+            self.frameVal = (self.frameVal > self.endVal) ? self.endVal : self.frameVal;
+        }
+
+        // decimal
+        self.frameVal = Math.round(self.frameVal*self.dec)/self.dec;
+
+        // format and print value
+        self.printValue(self.frameVal);
+
+        // whether to continue
+        if (progress < self.duration) {
+            self.rAF = requestAnimationFrame(self.count);
+        } else {
+            if (self.callback) self.callback();
+        }
+    };
+    // start your animation
+    this.start = function(callback) {
+        self.callback = callback;
+        self.rAF = requestAnimationFrame(self.count);
+        return false;
+    };
+    // toggles pause/resume animation
+    this.pauseResume = function() {
+        if (!self.paused) {
+            self.paused = true;
+            cancelAnimationFrame(self.rAF);
+        } else {
+            self.paused = false;
+            delete self.startTime;
+            self.duration = self.remaining;
+            self.startVal = self.frameVal;
+            requestAnimationFrame(self.count);
+        }
+    };
+    // reset to startVal so animation can be run again
+    this.reset = function() {
+        self.paused = false;
+        delete self.startTime;
+        self.startVal = startVal;
+        cancelAnimationFrame(self.rAF);
+        self.printValue(self.startVal);
+    };
+    // pass a new endVal and start animation
+    this.update = function (newEndVal) {
+        cancelAnimationFrame(self.rAF);
+        self.paused = false;
+        delete self.startTime;
+        self.startVal = self.frameVal;
+        self.endVal = Number(newEndVal);
+        self.countDown = (self.startVal > self.endVal);
+        self.rAF = requestAnimationFrame(self.count);
+    };
+    this.formatNumber = function(nStr) {
+        nStr = nStr.toFixed(self.decimals);
+        nStr += '';
+        var x, x1, x2, rgx;
+        x = nStr.split('.');
+        x1 = x[0];
+        x2 = x.length > 1 ? self.options.decimal + x[1] : '';
+        rgx = /(\d+)(\d{3})/;
+        if (self.options.useGrouping) {
+            while (rgx.test(x1)) {
+                x1 = x1.replace(rgx, '$1' + self.options.separator + '$2');
+            }
+        }
+        return self.options.prefix + x1 + x2 + self.options.suffix;
+    };
+
+    // format startVal on initialization
+    self.printValue(self.startVal);
+};
+
+// Example:
+// var numAnim = new countUp("SomeElementYouWantToAnimate", 0, 99.99, 2, 2.5);
+// numAnim.start();
+// numAnim.update(135);
+// with optional callback:
+// numAnim.start(someMethodToCallOnComplete);
+
+return CountUp;
 
 }));
 
@@ -7448,647 +7448,647 @@ Copyright © 2011-2015 Caleb Troughton
 Licensed under the MIT license.
 https://github.com/imakewebthings/waypoints/blog/master/licenses.txt
 */
-(function () {
-    'use strict'
+(function() {
+  'use strict'
 
-    var keyCounter = 0
-    var allWaypoints = {}
+  var keyCounter = 0
+  var allWaypoints = {}
 
-    /* http://imakewebthings.com/waypoints/api/waypoint */
-    function Waypoint(options) {
-        if (!options) {
-            throw new Error('No options passed to Waypoint constructor')
-        }
-        if (!options.element) {
-            throw new Error('No element option passed to Waypoint constructor')
-        }
-        if (!options.handler) {
-            throw new Error('No handler option passed to Waypoint constructor')
-        }
-
-        this.key = 'waypoint-' + keyCounter
-        this.options = Waypoint.Adapter.extend({}, Waypoint.defaults, options)
-        this.element = this.options.element
-        this.adapter = new Waypoint.Adapter(this.element)
-        this.callback = options.handler
-        this.axis = this.options.horizontal ? 'horizontal' : 'vertical'
-        this.enabled = this.options.enabled
-        this.triggerPoint = null
-        this.group = Waypoint.Group.findOrCreate({
-            name: this.options.group,
-            axis: this.axis
-        })
-        this.context = Waypoint.Context.findOrCreateByElement(this.options.context)
-
-        if (Waypoint.offsetAliases[this.options.offset]) {
-            this.options.offset = Waypoint.offsetAliases[this.options.offset]
-        }
-        this.group.add(this)
-        this.context.add(this)
-        allWaypoints[this.key] = this
-        keyCounter += 1
+  /* http://imakewebthings.com/waypoints/api/waypoint */
+  function Waypoint(options) {
+    if (!options) {
+      throw new Error('No options passed to Waypoint constructor')
+    }
+    if (!options.element) {
+      throw new Error('No element option passed to Waypoint constructor')
+    }
+    if (!options.handler) {
+      throw new Error('No handler option passed to Waypoint constructor')
     }
 
-    /* Private */
-    Waypoint.prototype.queueTrigger = function (direction) {
-        this.group.queueTrigger(this, direction)
+    this.key = 'waypoint-' + keyCounter
+    this.options = Waypoint.Adapter.extend({}, Waypoint.defaults, options)
+    this.element = this.options.element
+    this.adapter = new Waypoint.Adapter(this.element)
+    this.callback = options.handler
+    this.axis = this.options.horizontal ? 'horizontal' : 'vertical'
+    this.enabled = this.options.enabled
+    this.triggerPoint = null
+    this.group = Waypoint.Group.findOrCreate({
+      name: this.options.group,
+      axis: this.axis
+    })
+    this.context = Waypoint.Context.findOrCreateByElement(this.options.context)
+
+    if (Waypoint.offsetAliases[this.options.offset]) {
+      this.options.offset = Waypoint.offsetAliases[this.options.offset]
     }
+    this.group.add(this)
+    this.context.add(this)
+    allWaypoints[this.key] = this
+    keyCounter += 1
+  }
 
-    /* Private */
-    Waypoint.prototype.trigger = function (args) {
-        if (!this.enabled) {
-            return
-        }
-        if (this.callback) {
-            this.callback.apply(this, args)
-        }
+  /* Private */
+  Waypoint.prototype.queueTrigger = function(direction) {
+    this.group.queueTrigger(this, direction)
+  }
+
+  /* Private */
+  Waypoint.prototype.trigger = function(args) {
+    if (!this.enabled) {
+      return
     }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/destroy */
-    Waypoint.prototype.destroy = function () {
-        this.context.remove(this)
-        this.group.remove(this)
-        delete allWaypoints[this.key]
+    if (this.callback) {
+      this.callback.apply(this, args)
     }
+  }
 
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/disable */
-    Waypoint.prototype.disable = function () {
-        this.enabled = false
-        return this
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/destroy */
+  Waypoint.prototype.destroy = function() {
+    this.context.remove(this)
+    this.group.remove(this)
+    delete allWaypoints[this.key]
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/disable */
+  Waypoint.prototype.disable = function() {
+    this.enabled = false
+    return this
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/enable */
+  Waypoint.prototype.enable = function() {
+    this.context.refresh()
+    this.enabled = true
+    return this
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/next */
+  Waypoint.prototype.next = function() {
+    return this.group.next(this)
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/previous */
+  Waypoint.prototype.previous = function() {
+    return this.group.previous(this)
+  }
+
+  /* Private */
+  Waypoint.invokeAll = function(method) {
+    var allWaypointsArray = []
+    for (var waypointKey in allWaypoints) {
+      allWaypointsArray.push(allWaypoints[waypointKey])
     }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/enable */
-    Waypoint.prototype.enable = function () {
-        this.context.refresh()
-        this.enabled = true
-        return this
+    for (var i = 0, end = allWaypointsArray.length; i < end; i++) {
+      allWaypointsArray[i][method]()
     }
+  }
 
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/next */
-    Waypoint.prototype.next = function () {
-        return this.group.next(this)
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/destroy-all */
+  Waypoint.destroyAll = function() {
+    Waypoint.invokeAll('destroy')
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/disable-all */
+  Waypoint.disableAll = function() {
+    Waypoint.invokeAll('disable')
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/enable-all */
+  Waypoint.enableAll = function() {
+    Waypoint.invokeAll('enable')
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/refresh-all */
+  Waypoint.refreshAll = function() {
+    Waypoint.Context.refreshAll()
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/viewport-height */
+  Waypoint.viewportHeight = function() {
+    return window.innerHeight || document.documentElement.clientHeight
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/viewport-width */
+  Waypoint.viewportWidth = function() {
+    return document.documentElement.clientWidth
+  }
+
+  Waypoint.adapters = []
+
+  Waypoint.defaults = {
+    context: window,
+    continuous: true,
+    enabled: true,
+    group: 'default',
+    horizontal: false,
+    offset: 0
+  }
+
+  Waypoint.offsetAliases = {
+    'bottom-in-view': function() {
+      return this.context.innerHeight() - this.adapter.outerHeight()
+    },
+    'right-in-view': function() {
+      return this.context.innerWidth() - this.adapter.outerWidth()
     }
+  }
 
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/previous */
-    Waypoint.prototype.previous = function () {
-        return this.group.previous(this)
-    }
-
-    /* Private */
-    Waypoint.invokeAll = function (method) {
-        var allWaypointsArray = []
-        for (var waypointKey in allWaypoints) {
-            allWaypointsArray.push(allWaypoints[waypointKey])
-        }
-        for (var i = 0, end = allWaypointsArray.length; i < end; i++) {
-            allWaypointsArray[i][method]()
-        }
-    }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/destroy-all */
-    Waypoint.destroyAll = function () {
-        Waypoint.invokeAll('destroy')
-    }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/disable-all */
-    Waypoint.disableAll = function () {
-        Waypoint.invokeAll('disable')
-    }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/enable-all */
-    Waypoint.enableAll = function () {
-        Waypoint.invokeAll('enable')
-    }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/refresh-all */
-    Waypoint.refreshAll = function () {
-        Waypoint.Context.refreshAll()
-    }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/viewport-height */
-    Waypoint.viewportHeight = function () {
-        return window.innerHeight || document.documentElement.clientHeight
-    }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/viewport-width */
-    Waypoint.viewportWidth = function () {
-        return document.documentElement.clientWidth
-    }
-
-    Waypoint.adapters = []
-
-    Waypoint.defaults = {
-        context: window,
-        continuous: true,
-        enabled: true,
-        group: 'default',
-        horizontal: false,
-        offset: 0
-    }
-
-    Waypoint.offsetAliases = {
-        'bottom-in-view': function () {
-            return this.context.innerHeight() - this.adapter.outerHeight()
-        },
-        'right-in-view': function () {
-            return this.context.innerWidth() - this.adapter.outerWidth()
-        }
-    }
-
-    window.Waypoint = Waypoint
+  window.Waypoint = Waypoint
 }())
-; (function () {
-    'use strict'
+;(function() {
+  'use strict'
 
-    function requestAnimationFrameShim(callback) {
-        window.setTimeout(callback, 1000 / 60)
+  function requestAnimationFrameShim(callback) {
+    window.setTimeout(callback, 1000 / 60)
+  }
+
+  var keyCounter = 0
+  var contexts = {}
+  var Waypoint = window.Waypoint
+  var oldWindowLoad = window.onload
+
+  /* http://imakewebthings.com/waypoints/api/context */
+  function Context(element) {
+    this.element = element
+    this.Adapter = Waypoint.Adapter
+    this.adapter = new this.Adapter(element)
+    this.key = 'waypoint-context-' + keyCounter
+    this.didScroll = false
+    this.didResize = false
+    this.oldScroll = {
+      x: this.adapter.scrollLeft(),
+      y: this.adapter.scrollTop()
+    }
+    this.waypoints = {
+      vertical: {},
+      horizontal: {}
     }
 
-    var keyCounter = 0
-    var contexts = {}
-    var Waypoint = window.Waypoint
-    var oldWindowLoad = window.onload
+    element.waypointContextKey = this.key
+    contexts[element.waypointContextKey] = this
+    keyCounter += 1
 
-    /* http://imakewebthings.com/waypoints/api/context */
-    function Context(element) {
-        this.element = element
-        this.Adapter = Waypoint.Adapter
-        this.adapter = new this.Adapter(element)
-        this.key = 'waypoint-context-' + keyCounter
-        this.didScroll = false
-        this.didResize = false
-        this.oldScroll = {
-            x: this.adapter.scrollLeft(),
-            y: this.adapter.scrollTop()
-        }
-        this.waypoints = {
-            vertical: {},
-            horizontal: {}
-        }
+    this.createThrottledScrollHandler()
+    this.createThrottledResizeHandler()
+  }
 
-        element.waypointContextKey = this.key
-        contexts[element.waypointContextKey] = this
-        keyCounter += 1
+  /* Private */
+  Context.prototype.add = function(waypoint) {
+    var axis = waypoint.options.horizontal ? 'horizontal' : 'vertical'
+    this.waypoints[axis][waypoint.key] = waypoint
+    this.refresh()
+  }
 
-        this.createThrottledScrollHandler()
-        this.createThrottledResizeHandler()
+  /* Private */
+  Context.prototype.checkEmpty = function() {
+    var horizontalEmpty = this.Adapter.isEmptyObject(this.waypoints.horizontal)
+    var verticalEmpty = this.Adapter.isEmptyObject(this.waypoints.vertical)
+    if (horizontalEmpty && verticalEmpty) {
+      this.adapter.off('.waypoints')
+      delete contexts[this.key]
+    }
+  }
+
+  /* Private */
+  Context.prototype.createThrottledResizeHandler = function() {
+    var self = this
+
+    function resizeHandler() {
+      self.handleResize()
+      self.didResize = false
     }
 
-    /* Private */
-    Context.prototype.add = function (waypoint) {
-        var axis = waypoint.options.horizontal ? 'horizontal' : 'vertical'
-        this.waypoints[axis][waypoint.key] = waypoint
-        this.refresh()
+    this.adapter.on('resize.waypoints', function() {
+      if (!self.didResize) {
+        self.didResize = true
+        Waypoint.requestAnimationFrame(resizeHandler)
+      }
+    })
+  }
+
+  /* Private */
+  Context.prototype.createThrottledScrollHandler = function() {
+    var self = this
+    function scrollHandler() {
+      self.handleScroll()
+      self.didScroll = false
     }
 
-    /* Private */
-    Context.prototype.checkEmpty = function () {
-        var horizontalEmpty = this.Adapter.isEmptyObject(this.waypoints.horizontal)
-        var verticalEmpty = this.Adapter.isEmptyObject(this.waypoints.vertical)
-        if (horizontalEmpty && verticalEmpty) {
-            this.adapter.off('.waypoints')
-            delete contexts[this.key]
-        }
+    this.adapter.on('scroll.waypoints', function() {
+      if (!self.didScroll || Waypoint.isTouch) {
+        self.didScroll = true
+        Waypoint.requestAnimationFrame(scrollHandler)
+      }
+    })
+  }
+
+  /* Private */
+  Context.prototype.handleResize = function() {
+    Waypoint.Context.refreshAll()
+  }
+
+  /* Private */
+  Context.prototype.handleScroll = function() {
+    var triggeredGroups = {}
+    var axes = {
+      horizontal: {
+        newScroll: this.adapter.scrollLeft(),
+        oldScroll: this.oldScroll.x,
+        forward: 'right',
+        backward: 'left'
+      },
+      vertical: {
+        newScroll: this.adapter.scrollTop(),
+        oldScroll: this.oldScroll.y,
+        forward: 'down',
+        backward: 'up'
+      }
     }
 
-    /* Private */
-    Context.prototype.createThrottledResizeHandler = function () {
-        var self = this
+    for (var axisKey in axes) {
+      var axis = axes[axisKey]
+      var isForward = axis.newScroll > axis.oldScroll
+      var direction = isForward ? axis.forward : axis.backward
 
-        function resizeHandler() {
-            self.handleResize()
-            self.didResize = false
+      for (var waypointKey in this.waypoints[axisKey]) {
+        var waypoint = this.waypoints[axisKey][waypointKey]
+        var wasBeforeTriggerPoint = axis.oldScroll < waypoint.triggerPoint
+        var nowAfterTriggerPoint = axis.newScroll >= waypoint.triggerPoint
+        var crossedForward = wasBeforeTriggerPoint && nowAfterTriggerPoint
+        var crossedBackward = !wasBeforeTriggerPoint && !nowAfterTriggerPoint
+        if (crossedForward || crossedBackward) {
+          waypoint.queueTrigger(direction)
+          triggeredGroups[waypoint.group.id] = waypoint.group
         }
-
-        this.adapter.on('resize.waypoints', function () {
-            if (!self.didResize) {
-                self.didResize = true
-                Waypoint.requestAnimationFrame(resizeHandler)
-            }
-        })
+      }
     }
 
-    /* Private */
-    Context.prototype.createThrottledScrollHandler = function () {
-        var self = this
-        function scrollHandler() {
-            self.handleScroll()
-            self.didScroll = false
-        }
-
-        this.adapter.on('scroll.waypoints', function () {
-            if (!self.didScroll || Waypoint.isTouch) {
-                self.didScroll = true
-                Waypoint.requestAnimationFrame(scrollHandler)
-            }
-        })
+    for (var groupKey in triggeredGroups) {
+      triggeredGroups[groupKey].flushTriggers()
     }
 
-    /* Private */
-    Context.prototype.handleResize = function () {
-        Waypoint.Context.refreshAll()
+    this.oldScroll = {
+      x: axes.horizontal.newScroll,
+      y: axes.vertical.newScroll
+    }
+  }
+
+  /* Private */
+  Context.prototype.innerHeight = function() {
+    /*eslint-disable eqeqeq */
+    if (this.element == this.element.window) {
+      return Waypoint.viewportHeight()
+    }
+    /*eslint-enable eqeqeq */
+    return this.adapter.innerHeight()
+  }
+
+  /* Private */
+  Context.prototype.remove = function(waypoint) {
+    delete this.waypoints[waypoint.axis][waypoint.key]
+    this.checkEmpty()
+  }
+
+  /* Private */
+  Context.prototype.innerWidth = function() {
+    /*eslint-disable eqeqeq */
+    if (this.element == this.element.window) {
+      return Waypoint.viewportWidth()
+    }
+    /*eslint-enable eqeqeq */
+    return this.adapter.innerWidth()
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/context-destroy */
+  Context.prototype.destroy = function() {
+    var allWaypoints = []
+    for (var axis in this.waypoints) {
+      for (var waypointKey in this.waypoints[axis]) {
+        allWaypoints.push(this.waypoints[axis][waypointKey])
+      }
+    }
+    for (var i = 0, end = allWaypoints.length; i < end; i++) {
+      allWaypoints[i].destroy()
+    }
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/context-refresh */
+  Context.prototype.refresh = function() {
+    /*eslint-disable eqeqeq */
+    var isWindow = this.element == this.element.window
+    /*eslint-enable eqeqeq */
+    var contextOffset = isWindow ? undefined : this.adapter.offset()
+    var triggeredGroups = {}
+    var axes
+
+    this.handleScroll()
+    axes = {
+      horizontal: {
+        contextOffset: isWindow ? 0 : contextOffset.left,
+        contextScroll: isWindow ? 0 : this.oldScroll.x,
+        contextDimension: this.innerWidth(),
+        oldScroll: this.oldScroll.x,
+        forward: 'right',
+        backward: 'left',
+        offsetProp: 'left'
+      },
+      vertical: {
+        contextOffset: isWindow ? 0 : contextOffset.top,
+        contextScroll: isWindow ? 0 : this.oldScroll.y,
+        contextDimension: this.innerHeight(),
+        oldScroll: this.oldScroll.y,
+        forward: 'down',
+        backward: 'up',
+        offsetProp: 'top'
+      }
     }
 
-    /* Private */
-    Context.prototype.handleScroll = function () {
-        var triggeredGroups = {}
-        var axes = {
-            horizontal: {
-                newScroll: this.adapter.scrollLeft(),
-                oldScroll: this.oldScroll.x,
-                forward: 'right',
-                backward: 'left'
-            },
-            vertical: {
-                newScroll: this.adapter.scrollTop(),
-                oldScroll: this.oldScroll.y,
-                forward: 'down',
-                backward: 'up'
-            }
-        }
+    for (var axisKey in axes) {
+      var axis = axes[axisKey]
+      for (var waypointKey in this.waypoints[axisKey]) {
+        var waypoint = this.waypoints[axisKey][waypointKey]
+        var adjustment = waypoint.options.offset
+        var oldTriggerPoint = waypoint.triggerPoint
+        var elementOffset = 0
+        var freshWaypoint = oldTriggerPoint == null
+        var contextModifier, wasBeforeScroll, nowAfterScroll
+        var triggeredBackward, triggeredForward
 
-        for (var axisKey in axes) {
-            var axis = axes[axisKey]
-            var isForward = axis.newScroll > axis.oldScroll
-            var direction = isForward ? axis.forward : axis.backward
-
-            for (var waypointKey in this.waypoints[axisKey]) {
-                var waypoint = this.waypoints[axisKey][waypointKey]
-                var wasBeforeTriggerPoint = axis.oldScroll < waypoint.triggerPoint
-                var nowAfterTriggerPoint = axis.newScroll >= waypoint.triggerPoint
-                var crossedForward = wasBeforeTriggerPoint && nowAfterTriggerPoint
-                var crossedBackward = !wasBeforeTriggerPoint && !nowAfterTriggerPoint
-                if (crossedForward || crossedBackward) {
-                    waypoint.queueTrigger(direction)
-                    triggeredGroups[waypoint.group.id] = waypoint.group
-                }
-            }
-        }
-
-        for (var groupKey in triggeredGroups) {
-            triggeredGroups[groupKey].flushTriggers()
-        }
-
-        this.oldScroll = {
-            x: axes.horizontal.newScroll,
-            y: axes.vertical.newScroll
-        }
-    }
-
-    /* Private */
-    Context.prototype.innerHeight = function () {
-        /*eslint-disable eqeqeq */
-        if (this.element == this.element.window) {
-            return Waypoint.viewportHeight()
-        }
-        /*eslint-enable eqeqeq */
-        return this.adapter.innerHeight()
-    }
-
-    /* Private */
-    Context.prototype.remove = function (waypoint) {
-        delete this.waypoints[waypoint.axis][waypoint.key]
-        this.checkEmpty()
-    }
-
-    /* Private */
-    Context.prototype.innerWidth = function () {
-        /*eslint-disable eqeqeq */
-        if (this.element == this.element.window) {
-            return Waypoint.viewportWidth()
-        }
-        /*eslint-enable eqeqeq */
-        return this.adapter.innerWidth()
-    }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/context-destroy */
-    Context.prototype.destroy = function () {
-        var allWaypoints = []
-        for (var axis in this.waypoints) {
-            for (var waypointKey in this.waypoints[axis]) {
-                allWaypoints.push(this.waypoints[axis][waypointKey])
-            }
-        }
-        for (var i = 0, end = allWaypoints.length; i < end; i++) {
-            allWaypoints[i].destroy()
-        }
-    }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/context-refresh */
-    Context.prototype.refresh = function () {
-        /*eslint-disable eqeqeq */
-        var isWindow = this.element == this.element.window
-        /*eslint-enable eqeqeq */
-        var contextOffset = isWindow ? undefined : this.adapter.offset()
-        var triggeredGroups = {}
-        var axes
-
-        this.handleScroll()
-        axes = {
-            horizontal: {
-                contextOffset: isWindow ? 0 : contextOffset.left,
-                contextScroll: isWindow ? 0 : this.oldScroll.x,
-                contextDimension: this.innerWidth(),
-                oldScroll: this.oldScroll.x,
-                forward: 'right',
-                backward: 'left',
-                offsetProp: 'left'
-            },
-            vertical: {
-                contextOffset: isWindow ? 0 : contextOffset.top,
-                contextScroll: isWindow ? 0 : this.oldScroll.y,
-                contextDimension: this.innerHeight(),
-                oldScroll: this.oldScroll.y,
-                forward: 'down',
-                backward: 'up',
-                offsetProp: 'top'
-            }
-        }
-
-        for (var axisKey in axes) {
-            var axis = axes[axisKey]
-            for (var waypointKey in this.waypoints[axisKey]) {
-                var waypoint = this.waypoints[axisKey][waypointKey]
-                var adjustment = waypoint.options.offset
-                var oldTriggerPoint = waypoint.triggerPoint
-                var elementOffset = 0
-                var freshWaypoint = oldTriggerPoint == null
-                var contextModifier, wasBeforeScroll, nowAfterScroll
-                var triggeredBackward, triggeredForward
-
-                if (waypoint.element !== waypoint.element.window) {
-                    elementOffset = waypoint.adapter.offset()[axis.offsetProp]
-                }
-
-                if (typeof adjustment === 'function') {
-                    adjustment = adjustment.apply(waypoint)
-                }
-                else if (typeof adjustment === 'string') {
-                    adjustment = parseFloat(adjustment)
-                    if (waypoint.options.offset.indexOf('%') > -1) {
-                        adjustment = Math.ceil(axis.contextDimension * adjustment / 100)
-                    }
-                }
-
-                contextModifier = axis.contextScroll - axis.contextOffset
-                waypoint.triggerPoint = elementOffset + contextModifier - adjustment
-                wasBeforeScroll = oldTriggerPoint < axis.oldScroll
-                nowAfterScroll = waypoint.triggerPoint >= axis.oldScroll
-                triggeredBackward = wasBeforeScroll && nowAfterScroll
-                triggeredForward = !wasBeforeScroll && !nowAfterScroll
-
-                if (!freshWaypoint && triggeredBackward) {
-                    waypoint.queueTrigger(axis.backward)
-                    triggeredGroups[waypoint.group.id] = waypoint.group
-                }
-                else if (!freshWaypoint && triggeredForward) {
-                    waypoint.queueTrigger(axis.forward)
-                    triggeredGroups[waypoint.group.id] = waypoint.group
-                }
-                else if (freshWaypoint && axis.oldScroll >= waypoint.triggerPoint) {
-                    waypoint.queueTrigger(axis.forward)
-                    triggeredGroups[waypoint.group.id] = waypoint.group
-                }
-            }
+        if (waypoint.element !== waypoint.element.window) {
+          elementOffset = waypoint.adapter.offset()[axis.offsetProp]
         }
 
-        Waypoint.requestAnimationFrame(function () {
-            for (var groupKey in triggeredGroups) {
-                triggeredGroups[groupKey].flushTriggers()
-            }
-        })
-
-        return this
-    }
-
-    /* Private */
-    Context.findOrCreateByElement = function (element) {
-        return Context.findByElement(element) || new Context(element)
-    }
-
-    /* Private */
-    Context.refreshAll = function () {
-        for (var contextId in contexts) {
-            contexts[contextId].refresh()
+        if (typeof adjustment === 'function') {
+          adjustment = adjustment.apply(waypoint)
         }
-    }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/context-find-by-element */
-    Context.findByElement = function (element) {
-        return contexts[element.waypointContextKey]
-    }
-
-    window.onload = function () {
-        if (oldWindowLoad) {
-            oldWindowLoad()
+        else if (typeof adjustment === 'string') {
+          adjustment = parseFloat(adjustment)
+          if (waypoint.options.offset.indexOf('%') > - 1) {
+            adjustment = Math.ceil(axis.contextDimension * adjustment / 100)
+          }
         }
-        Context.refreshAll()
-    }
 
-    Waypoint.requestAnimationFrame = function (callback) {
-        var requestFn = window.requestAnimationFrame ||
-          window.mozRequestAnimationFrame ||
-          window.webkitRequestAnimationFrame ||
-          requestAnimationFrameShim
-        requestFn.call(window, callback)
-    }
-    Waypoint.Context = Context
-}())
-; (function () {
-    'use strict'
+        contextModifier = axis.contextScroll - axis.contextOffset
+        waypoint.triggerPoint = elementOffset + contextModifier - adjustment
+        wasBeforeScroll = oldTriggerPoint < axis.oldScroll
+        nowAfterScroll = waypoint.triggerPoint >= axis.oldScroll
+        triggeredBackward = wasBeforeScroll && nowAfterScroll
+        triggeredForward = !wasBeforeScroll && !nowAfterScroll
 
-    function byTriggerPoint(a, b) {
-        return a.triggerPoint - b.triggerPoint
-    }
-
-    function byReverseTriggerPoint(a, b) {
-        return b.triggerPoint - a.triggerPoint
-    }
-
-    var groups = {
-        vertical: {},
-        horizontal: {}
-    }
-    var Waypoint = window.Waypoint
-
-    /* http://imakewebthings.com/waypoints/api/group */
-    function Group(options) {
-        this.name = options.name
-        this.axis = options.axis
-        this.id = this.name + '-' + this.axis
-        this.waypoints = []
-        this.clearTriggerQueues()
-        groups[this.axis][this.name] = this
-    }
-
-    /* Private */
-    Group.prototype.add = function (waypoint) {
-        this.waypoints.push(waypoint)
-    }
-
-    /* Private */
-    Group.prototype.clearTriggerQueues = function () {
-        this.triggerQueues = {
-            up: [],
-            down: [],
-            left: [],
-            right: []
+        if (!freshWaypoint && triggeredBackward) {
+          waypoint.queueTrigger(axis.backward)
+          triggeredGroups[waypoint.group.id] = waypoint.group
         }
-    }
-
-    /* Private */
-    Group.prototype.flushTriggers = function () {
-        for (var direction in this.triggerQueues) {
-            var waypoints = this.triggerQueues[direction]
-            var reverse = direction === 'up' || direction === 'left'
-            waypoints.sort(reverse ? byReverseTriggerPoint : byTriggerPoint)
-            for (var i = 0, end = waypoints.length; i < end; i += 1) {
-                var waypoint = waypoints[i]
-                if (waypoint.options.continuous || i === waypoints.length - 1) {
-                    waypoint.trigger([direction])
-                }
-            }
+        else if (!freshWaypoint && triggeredForward) {
+          waypoint.queueTrigger(axis.forward)
+          triggeredGroups[waypoint.group.id] = waypoint.group
         }
-        this.clearTriggerQueues()
-    }
-
-    /* Private */
-    Group.prototype.next = function (waypoint) {
-        this.waypoints.sort(byTriggerPoint)
-        var index = Waypoint.Adapter.inArray(waypoint, this.waypoints)
-        var isLast = index === this.waypoints.length - 1
-        return isLast ? null : this.waypoints[index + 1]
-    }
-
-    /* Private */
-    Group.prototype.previous = function (waypoint) {
-        this.waypoints.sort(byTriggerPoint)
-        var index = Waypoint.Adapter.inArray(waypoint, this.waypoints)
-        return index ? this.waypoints[index - 1] : null
-    }
-
-    /* Private */
-    Group.prototype.queueTrigger = function (waypoint, direction) {
-        this.triggerQueues[direction].push(waypoint)
-    }
-
-    /* Private */
-    Group.prototype.remove = function (waypoint) {
-        var index = Waypoint.Adapter.inArray(waypoint, this.waypoints)
-        if (index > -1) {
-            this.waypoints.splice(index, 1)
+        else if (freshWaypoint && axis.oldScroll >= waypoint.triggerPoint) {
+          waypoint.queueTrigger(axis.forward)
+          triggeredGroups[waypoint.group.id] = waypoint.group
         }
+      }
     }
 
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/first */
-    Group.prototype.first = function () {
-        return this.waypoints[0]
-    }
-
-    /* Public */
-    /* http://imakewebthings.com/waypoints/api/last */
-    Group.prototype.last = function () {
-        return this.waypoints[this.waypoints.length - 1]
-    }
-
-    /* Private */
-    Group.findOrCreate = function (options) {
-        return groups[options.axis][options.name] || new Group(options)
-    }
-
-    Waypoint.Group = Group
-}())
-; (function () {
-    'use strict'
-
-    var $ = window.jQuery
-    var Waypoint = window.Waypoint
-
-    function JQueryAdapter(element) {
-        this.$element = $(element)
-    }
-
-    $.each([
-      'innerHeight',
-      'innerWidth',
-      'off',
-      'offset',
-      'on',
-      'outerHeight',
-      'outerWidth',
-      'scrollLeft',
-      'scrollTop'
-    ], function (i, method) {
-        JQueryAdapter.prototype[method] = function () {
-            var args = Array.prototype.slice.call(arguments)
-            return this.$element[method].apply(this.$element, args)
-        }
+    Waypoint.requestAnimationFrame(function() {
+      for (var groupKey in triggeredGroups) {
+        triggeredGroups[groupKey].flushTriggers()
+      }
     })
 
-    $.each([
-      'extend',
-      'inArray',
-      'isEmptyObject'
-    ], function (i, method) {
-        JQueryAdapter[method] = $[method]
-    })
+    return this
+  }
 
-    Waypoint.adapters.push({
-        name: 'jquery',
-        Adapter: JQueryAdapter
-    })
-    Waypoint.Adapter = JQueryAdapter
+  /* Private */
+  Context.findOrCreateByElement = function(element) {
+    return Context.findByElement(element) || new Context(element)
+  }
+
+  /* Private */
+  Context.refreshAll = function() {
+    for (var contextId in contexts) {
+      contexts[contextId].refresh()
+    }
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/context-find-by-element */
+  Context.findByElement = function(element) {
+    return contexts[element.waypointContextKey]
+  }
+
+  window.onload = function() {
+    if (oldWindowLoad) {
+      oldWindowLoad()
+    }
+    Context.refreshAll()
+  }
+
+  Waypoint.requestAnimationFrame = function(callback) {
+    var requestFn = window.requestAnimationFrame ||
+      window.mozRequestAnimationFrame ||
+      window.webkitRequestAnimationFrame ||
+      requestAnimationFrameShim
+    requestFn.call(window, callback)
+  }
+  Waypoint.Context = Context
 }())
-; (function () {
-    'use strict'
+;(function() {
+  'use strict'
 
-    var Waypoint = window.Waypoint
+  function byTriggerPoint(a, b) {
+    return a.triggerPoint - b.triggerPoint
+  }
 
-    function createExtension(framework) {
-        return function () {
-            var waypoints = []
-            var overrides = arguments[0]
+  function byReverseTriggerPoint(a, b) {
+    return b.triggerPoint - a.triggerPoint
+  }
 
-            if (framework.isFunction(arguments[0])) {
-                overrides = framework.extend({}, arguments[1])
-                overrides.handler = arguments[0]
-            }
+  var groups = {
+    vertical: {},
+    horizontal: {}
+  }
+  var Waypoint = window.Waypoint
 
-            this.each(function () {
-                var options = framework.extend({}, overrides, {
-                    element: this
-                })
-                if (typeof options.context === 'string') {
-                    options.context = framework(this).closest(options.context)[0]
-                }
-                waypoints.push(new Waypoint(options))
-            })
+  /* http://imakewebthings.com/waypoints/api/group */
+  function Group(options) {
+    this.name = options.name
+    this.axis = options.axis
+    this.id = this.name + '-' + this.axis
+    this.waypoints = []
+    this.clearTriggerQueues()
+    groups[this.axis][this.name] = this
+  }
 
-            return waypoints
+  /* Private */
+  Group.prototype.add = function(waypoint) {
+    this.waypoints.push(waypoint)
+  }
+
+  /* Private */
+  Group.prototype.clearTriggerQueues = function() {
+    this.triggerQueues = {
+      up: [],
+      down: [],
+      left: [],
+      right: []
+    }
+  }
+
+  /* Private */
+  Group.prototype.flushTriggers = function() {
+    for (var direction in this.triggerQueues) {
+      var waypoints = this.triggerQueues[direction]
+      var reverse = direction === 'up' || direction === 'left'
+      waypoints.sort(reverse ? byReverseTriggerPoint : byTriggerPoint)
+      for (var i = 0, end = waypoints.length; i < end; i += 1) {
+        var waypoint = waypoints[i]
+        if (waypoint.options.continuous || i === waypoints.length - 1) {
+          waypoint.trigger([direction])
         }
+      }
     }
+    this.clearTriggerQueues()
+  }
 
-    if (window.jQuery) {
-        window.jQuery.fn.waypoint = createExtension(window.jQuery)
+  /* Private */
+  Group.prototype.next = function(waypoint) {
+    this.waypoints.sort(byTriggerPoint)
+    var index = Waypoint.Adapter.inArray(waypoint, this.waypoints)
+    var isLast = index === this.waypoints.length - 1
+    return isLast ? null : this.waypoints[index + 1]
+  }
+
+  /* Private */
+  Group.prototype.previous = function(waypoint) {
+    this.waypoints.sort(byTriggerPoint)
+    var index = Waypoint.Adapter.inArray(waypoint, this.waypoints)
+    return index ? this.waypoints[index - 1] : null
+  }
+
+  /* Private */
+  Group.prototype.queueTrigger = function(waypoint, direction) {
+    this.triggerQueues[direction].push(waypoint)
+  }
+
+  /* Private */
+  Group.prototype.remove = function(waypoint) {
+    var index = Waypoint.Adapter.inArray(waypoint, this.waypoints)
+    if (index > -1) {
+      this.waypoints.splice(index, 1)
     }
-    if (window.Zepto) {
-        window.Zepto.fn.waypoint = createExtension(window.Zepto)
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/first */
+  Group.prototype.first = function() {
+    return this.waypoints[0]
+  }
+
+  /* Public */
+  /* http://imakewebthings.com/waypoints/api/last */
+  Group.prototype.last = function() {
+    return this.waypoints[this.waypoints.length - 1]
+  }
+
+  /* Private */
+  Group.findOrCreate = function(options) {
+    return groups[options.axis][options.name] || new Group(options)
+  }
+
+  Waypoint.Group = Group
+}())
+;(function() {
+  'use strict'
+
+  var $ = window.jQuery
+  var Waypoint = window.Waypoint
+
+  function JQueryAdapter(element) {
+    this.$element = $(element)
+  }
+
+  $.each([
+    'innerHeight',
+    'innerWidth',
+    'off',
+    'offset',
+    'on',
+    'outerHeight',
+    'outerWidth',
+    'scrollLeft',
+    'scrollTop'
+  ], function(i, method) {
+    JQueryAdapter.prototype[method] = function() {
+      var args = Array.prototype.slice.call(arguments)
+      return this.$element[method].apply(this.$element, args)
     }
+  })
+
+  $.each([
+    'extend',
+    'inArray',
+    'isEmptyObject'
+  ], function(i, method) {
+    JQueryAdapter[method] = $[method]
+  })
+
+  Waypoint.adapters.push({
+    name: 'jquery',
+    Adapter: JQueryAdapter
+  })
+  Waypoint.Adapter = JQueryAdapter
+}())
+;(function() {
+  'use strict'
+
+  var Waypoint = window.Waypoint
+
+  function createExtension(framework) {
+    return function() {
+      var waypoints = []
+      var overrides = arguments[0]
+
+      if (framework.isFunction(arguments[0])) {
+        overrides = framework.extend({}, arguments[1])
+        overrides.handler = arguments[0]
+      }
+
+      this.each(function() {
+        var options = framework.extend({}, overrides, {
+          element: this
+        })
+        if (typeof options.context === 'string') {
+          options.context = framework(this).closest(options.context)[0]
+        }
+        waypoints.push(new Waypoint(options))
+      })
+
+      return waypoints
+    }
+  }
+
+  if (window.jQuery) {
+    window.jQuery.fn.waypoint = createExtension(window.jQuery)
+  }
+  if (window.Zepto) {
+    window.Zepto.fn.waypoint = createExtension(window.Zepto)
+  }
 }())
 ;
 /**
@@ -8124,284 +8124,284 @@ https://github.com/imakewebthings/waypoints/blog/master/licenses.txt
  **/
 
 
-(function (window, document, $) {
-    'use strict';
+(function(window, document, $) {
+  'use strict';
 
-    // Plugin private cache
-    // static vars
-    var cache = {
-        filterId: 0
+  // Plugin private cache
+  // static vars
+  var cache = {
+    filterId: 0
+  },
+    $body = $('body');
+
+  var Vague = function(elm, customOptions) {
+    // Default options
+    var defaultOptions = {
+      intensity: 5,
+      forceSVGUrl: false,
+      animationOptions: {
+        duration: 1000,
+        easing: 'linear'
+      }
     },
-      $body = $('body');
+      // extend the default options with the ones passed to the plugin
+      options = $.extend(defaultOptions, customOptions),
 
-    var Vague = function (elm, customOptions) {
-        // Default options
-        var defaultOptions = {
-            intensity: 5,
-            forceSVGUrl: false,
-            animationOptions: {
-                duration: 1000,
-                easing: 'linear'
-            }
-        },
-          // extend the default options with the ones passed to the plugin
-          options = $.extend(defaultOptions, customOptions),
+      /*
+       *
+       * Helpers
+       *
+       */
 
-          /*
-           *
-           * Helpers
-           *
-           */
+      _browserPrefixes = ' -webkit- -moz- -o- -ms- '.split(' '),
+      _cssPrefixString = {},
+      _cssPrefix = function(property) {
+        if (_cssPrefixString[property] || _cssPrefixString[property] === '') return _cssPrefixString[property] + property;
+        var e = document.createElement('div');
+        var prefixes = ['', 'Moz', 'Webkit', 'O', 'ms', 'Khtml']; // Various supports...
+        for (var i in prefixes) {
+          if (typeof e.style[prefixes[i] + property] !== 'undefined') {
+            _cssPrefixString[property] = prefixes[i];
+            return prefixes[i] + property;
+          }
+        }
+        return property.toLowerCase();
+      },
+      // https://github.com/Modernizr/Modernizr/blob/master/feature-detects/css-filters.js
+      _support = {
+        cssfilters: function() {
+          var el = document.createElement('div');
+          el.style.cssText = _browserPrefixes.join('filter' + ':blur(2px); ');
+          return !!el.style.length && ((document.documentMode === undefined || document.documentMode > 9));
+        }(),
 
-          _browserPrefixes = ' -webkit- -moz- -o- -ms- '.split(' '),
-          _cssPrefixString = {},
-          _cssPrefix = function (property) {
-              if (_cssPrefixString[property] || _cssPrefixString[property] === '') return _cssPrefixString[property] + property;
-              var e = document.createElement('div');
-              var prefixes = ['', 'Moz', 'Webkit', 'O', 'ms', 'Khtml']; // Various supports...
-              for (var i in prefixes) {
-                  if (typeof e.style[prefixes[i] + property] !== 'undefined') {
-                      _cssPrefixString[property] = prefixes[i];
-                      return prefixes[i] + property;
-                  }
-              }
-              return property.toLowerCase();
-          },
-          // https://github.com/Modernizr/Modernizr/blob/master/feature-detects/css-filters.js
-          _support = {
-              cssfilters: function () {
-                  var el = document.createElement('div');
-                  el.style.cssText = _browserPrefixes.join('filter' + ':blur(2px); ');
-                  return !!el.style.length && ((document.documentMode === undefined || document.documentMode > 9));
-              }(),
+        // https://github.com/Modernizr/Modernizr/blob/master/feature-detects/svg-filters.js
+        svgfilters: function() {
+          var result = false;
+          try {
+            result = typeof SVGFEColorMatrixElement !== undefined &&
+              SVGFEColorMatrixElement.SVG_FECOLORMATRIX_TYPE_SATURATE == 2;
+          } catch (e) {}
+          return result;
+        }()
+      },
 
-              // https://github.com/Modernizr/Modernizr/blob/master/feature-detects/svg-filters.js
-              svgfilters: function () {
-                  var result = false;
-                  try {
-                      result = typeof SVGFEColorMatrixElement !== undefined &&
-                        SVGFEColorMatrixElement.SVG_FECOLORMATRIX_TYPE_SATURATE == 2;
-                  } catch (e) { }
-                  return result;
-              }()
-          },
+      /*
+       *
+       * PRIVATE VARS
+       *
+       */
 
-          /*
-           *
-           * PRIVATE VARS
-           *
-           */
+      _blurred = false,
+      // cache the right prefixed css filter property
+      _cssFilterProp = _cssPrefix('Filter'),
+      _svgGaussianFilter,
+      _filterId,
+      // to cache the jquery animation instance
+      _animation,
 
-          _blurred = false,
-          // cache the right prefixed css filter property
-          _cssFilterProp = _cssPrefix('Filter'),
-          _svgGaussianFilter,
-          _filterId,
-          // to cache the jquery animation instance
-          _animation,
+      /*
+       *
+       * PRIVATE METHODS
+       *
+       */
 
-          /*
-           *
-           * PRIVATE METHODS
-           *
-           */
+      /**
+       * Create any svg element
+       * @param  { String } tagName: svg tag name
+       * @return { SVG Node }
+       */
 
-          /**
-           * Create any svg element
-           * @param  { String } tagName: svg tag name
-           * @return { SVG Node }
-           */
+      _createSvgElement = function(tagName) {
+        return document.createElementNS('http://www.w3.org/2000/svg', tagName);
+      },
 
-          _createSvgElement = function (tagName) {
-              return document.createElementNS('http://www.w3.org/2000/svg', tagName);
-          },
+      /**
+       *
+       * Inject the svg tag into the DOM
+       * we will use it only if the css filters are not supported
+       *
+       */
 
-          /**
-           *
-           * Inject the svg tag into the DOM
-           * we will use it only if the css filters are not supported
-           *
-           */
+      _appendSVGFilter = function() {
+        // create the svg and the filter tags
+        var svg = _createSvgElement('svg'),
+          filter = _createSvgElement('filter');
 
-          _appendSVGFilter = function () {
-              // create the svg and the filter tags
-              var svg = _createSvgElement('svg'),
-                filter = _createSvgElement('filter');
+        // cache the feGaussianBlur tag and make it available
+        // outside of this function to easily update the blur intensity
+        _svgGaussianFilter = _createSvgElement('feGaussianBlur');
 
-              // cache the feGaussianBlur tag and make it available
-              // outside of this function to easily update the blur intensity
-              _svgGaussianFilter = _createSvgElement('feGaussianBlur');
+        // hide the svg tag
+        // we don't want to see it into the DOM!
+        svg.setAttribute('style', 'position:absolute');
+        svg.setAttribute('width', '0');
+        svg.setAttribute('height', '0');
+        // set the id that will be used as link between the DOM element to blur and the svg just created
+        filter.setAttribute('id', 'blur-effect-id-' + cache.filterId);
 
-              // hide the svg tag
-              // we don't want to see it into the DOM!
-              svg.setAttribute('style', 'position:absolute');
-              svg.setAttribute('width', '0');
-              svg.setAttribute('height', '0');
-              // set the id that will be used as link between the DOM element to blur and the svg just created
-              filter.setAttribute('id', 'blur-effect-id-' + cache.filterId);
+        filter.appendChild(_svgGaussianFilter);
+        svg.appendChild(filter);
+        // append the svg into the body
+        $body.append(svg);
 
-              filter.appendChild(_svgGaussianFilter);
-              svg.appendChild(filter);
-              // append the svg into the body
-              $body.append(svg);
+      };
 
-          };
+    /*
+     *
+     * PUBLIC VARS
+     *
+     */
 
-        /*
-         *
-         * PUBLIC VARS
-         *
-         */
-
-        // cache the DOM element to blur
-        this.$elm = elm instanceof $ ? elm : $(elm);
+    // cache the DOM element to blur
+    this.$elm = elm instanceof $ ? elm : $(elm);
 
 
-        /*
-         *
-         * PUBLIC METHODS
-         *
-         */
+    /*
+     *
+     * PUBLIC METHODS
+     *
+     */
 
-        /**
-         *
-         * Initialize the plugin creating a new svg if necessary
-         *
-         */
+    /**
+     *
+     * Initialize the plugin creating a new svg if necessary
+     *
+     */
 
-        this.init = function () {
-            // checking the css filter feature
-            if (_support.svgfilters) {
-                _appendSVGFilter();
-            }
-            // cache the filter id
-            _filterId = cache.filterId;
-            // increment the filter id static var
-            cache.filterId++;
+    this.init = function() {
+      // checking the css filter feature
+      if (_support.svgfilters) {
+        _appendSVGFilter();
+      }
+      // cache the filter id
+      _filterId = cache.filterId;
+      // increment the filter id static var
+      cache.filterId++;
 
-            return this;
+      return this;
 
-        };
-
-        /**
-         *
-         * Blur the DOM element selected
-         *
-         */
-
-        this.blur = function () {
-
-            var cssFilterValue,
-              // variables needed to force the svg filter URL
-              loc = window.location,
-              svgUrl = options.forceSVGUrl ? loc.protocol + '//' + loc.host + loc.pathname + loc.search : '';
-
-            // use the css filters if supported
-            if (_support.cssfilters) {
-                cssFilterValue = 'blur(' + options.intensity + 'px)';
-                // .. or use the svg filters
-            } else if (_support.svgfilters) {
-                // update the svg stdDeviation tag to set up the blur intensity
-                _svgGaussianFilter.setAttribute('stdDeviation', options.intensity);
-                cssFilterValue = 'url(' + svgUrl + '#blur-effect-id-' + _filterId + ')';
-            } else {
-                // .. use the IE css filters
-                cssFilterValue = 'progid:DXImageTransform.Microsoft.Blur(pixelradius=' + options.intensity + ')';
-            }
-
-            // update the DOM element css
-            this.$elm[0].style[_cssFilterProp] = cssFilterValue;
-            // set the _blurred internal var to true to cache the element current status
-            _blurred = true;
-
-            return this;
-        };
-
-
-        /**
-         * Animate the blur intensity
-         * @param  { Int } newIntensity: new blur intensity value
-         * @param  { Object } customAnimationOptions: default jQuery animate options
-         */
-
-        this.animate = function (newIntensity, customAnimationOptions) {
-            // control the new blur intensity checking if it's a valid value
-            if (typeof newIntensity !== 'number') {
-                throw (typeof newIntensity + ' is not a valid number to animate the blur');
-            } else if (newIntensity < 0) {
-                throw ('I can animate only positive numbers');
-            }
-            // create a new jQuery deferred instance
-            var dfr = new $.Deferred();
-
-            // kill the previous animation
-            if (_animation) {
-                _animation.stop(true, true);
-            }
-
-            // trigger the animation using the jQuery Animation class
-            _animation = new $.Animation(options, {
-                intensity: newIntensity
-            }, $.extend(options.animationOptions, customAnimationOptions))
-              .progress($.proxy(this.blur, this))
-              .done(dfr.resolve);
-
-            // return the animation deferred promise
-            return dfr.promise();
-        };
-
-        /**
-         *
-         * Unblur the DOM element
-         *
-         */
-        this.unblur = function () {
-            // set the DOM filter property to none
-            this.$elm.css(_cssFilterProp, 'none');
-            _blurred = false;
-            return this;
-        };
-
-        /**
-         *
-         * Trigger alternatively the @blur and @unblur methods
-         *
-         */
-
-        this.toggleblur = function () {
-            if (_blurred) {
-                this.unblur();
-            } else {
-                this.blur();
-            }
-            return this;
-        };
-        /**
-         * Destroy the Vague.js instance removing also the svg filter injected into the DOM
-         */
-        this.destroy = function () {
-            // do we need to remove the svg filter?
-            if (_support.svgfilters) {
-                $('filter#blur-effect-id-' + _filterId).parent().remove();
-            }
-
-            this.unblur();
-
-            // clear all the property stored into this Vague.js instance
-            for (var prop in this) {
-                delete this[prop];
-            }
-
-            return this;
-        };
-        // init the plugin
-        return this.init();
     };
 
-    // export the plugin as a jQuery function
-    $.fn.Vague = function (options) {
-        return new Vague(this, options);
+    /**
+     *
+     * Blur the DOM element selected
+     *
+     */
+
+    this.blur = function() {
+
+      var cssFilterValue,
+        // variables needed to force the svg filter URL
+        loc = window.location,
+        svgUrl = options.forceSVGUrl ? loc.protocol + '//' + loc.host + loc.pathname + loc.search : '';
+
+      // use the css filters if supported
+      if (_support.cssfilters) {
+        cssFilterValue = 'blur(' + options.intensity + 'px)';
+        // .. or use the svg filters
+      } else if (_support.svgfilters) {
+        // update the svg stdDeviation tag to set up the blur intensity
+        _svgGaussianFilter.setAttribute('stdDeviation', options.intensity);
+        cssFilterValue = 'url(' + svgUrl + '#blur-effect-id-' + _filterId + ')';
+      } else {
+        // .. use the IE css filters
+        cssFilterValue = 'progid:DXImageTransform.Microsoft.Blur(pixelradius=' + options.intensity + ')';
+      }
+
+      // update the DOM element css
+      this.$elm[0].style[_cssFilterProp] = cssFilterValue;
+      // set the _blurred internal var to true to cache the element current status
+      _blurred = true;
+
+      return this;
     };
+
+
+    /**
+     * Animate the blur intensity
+     * @param  { Int } newIntensity: new blur intensity value
+     * @param  { Object } customAnimationOptions: default jQuery animate options
+     */
+
+    this.animate = function(newIntensity, customAnimationOptions) {
+      // control the new blur intensity checking if it's a valid value
+      if (typeof newIntensity !== 'number') {
+        throw (typeof newIntensity + ' is not a valid number to animate the blur');
+      } else if (newIntensity < 0) {
+        throw ('I can animate only positive numbers');
+      }
+      // create a new jQuery deferred instance
+      var dfr = new $.Deferred();
+
+      // kill the previous animation
+      if (_animation) {
+        _animation.stop(true, true);
+      }
+
+      // trigger the animation using the jQuery Animation class
+      _animation = new $.Animation(options, {
+        intensity: newIntensity
+      }, $.extend(options.animationOptions, customAnimationOptions))
+        .progress($.proxy(this.blur, this))
+        .done(dfr.resolve);
+
+      // return the animation deferred promise
+      return dfr.promise();
+    };
+
+    /**
+     *
+     * Unblur the DOM element
+     *
+     */
+    this.unblur = function() {
+      // set the DOM filter property to none
+      this.$elm.css(_cssFilterProp, 'none');
+      _blurred = false;
+      return this;
+    };
+
+    /**
+     *
+     * Trigger alternatively the @blur and @unblur methods
+     *
+     */
+
+    this.toggleblur = function() {
+      if (_blurred) {
+        this.unblur();
+      } else {
+        this.blur();
+      }
+      return this;
+    };
+    /**
+     * Destroy the Vague.js instance removing also the svg filter injected into the DOM
+     */
+    this.destroy = function() {
+      // do we need to remove the svg filter?
+      if (_support.svgfilters) {
+        $('filter#blur-effect-id-' + _filterId).parent().remove();
+      }
+
+      this.unblur();
+
+      // clear all the property stored into this Vague.js instance
+      for (var prop in this) {
+        delete this[prop];
+      }
+
+      return this;
+    };
+    // init the plugin
+    return this.init();
+  };
+
+  // export the plugin as a jQuery function
+  $.fn.Vague = function(options) {
+    return new Vague(this, options);
+  };
 
 }(window, document, jQuery));
 
@@ -10594,31 +10594,31 @@ $special = $event.special.debouncedresize = {
 };
 
 if (!Function.prototype.bind) {
-    Function.prototype.bind = function (oThis) {
-        if (typeof this !== 'function') {
-            // closest thing possible to the ECMAScript 5
-            // internal IsCallable function
-            throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
-        }
+  Function.prototype.bind = function(oThis) {
+    if (typeof this !== 'function') {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError('Function.prototype.bind - what is trying to be bound is not callable');
+    }
 
-        var aArgs = Array.prototype.slice.call(arguments, 1),
-            fToBind = this,
-            fNOP = function () { },
-            fBound = function () {
-                return fToBind.apply(this instanceof fNOP
-                       ? this
-                       : oThis,
-                       aArgs.concat(Array.prototype.slice.call(arguments)));
-            };
+    var aArgs   = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP    = function() {},
+        fBound  = function() {
+          return fToBind.apply(this instanceof fNOP
+                 ? this
+                 : oThis,
+                 aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
 
-        if (this.prototype) {
-            // native functions don't have a prototype
-            fNOP.prototype = this.prototype;
-        }
-        fBound.prototype = new fNOP();
+    if (this.prototype) {
+      // native functions don't have a prototype
+      fNOP.prototype = this.prototype;
+    }
+    fBound.prototype = new fNOP();
 
-        return fBound;
-    };
+    return fBound;
+  };
 }
 
 // Begin gatag.js
@@ -10631,66 +10631,66 @@ if (!Function.prototype.bind) {
 // 7/14/14 Added Office 2010 file extensions. Changed "click" to "mousedown". Added support for 2 dashboards.
 
 function addGAToDownloadLinks() {
-    if (document.getElementsByTagName) {
-        // Initialize external link handlers
-        var hrefs = document.getElementsByTagName("a");
-        for (var l = 0; l < hrefs.length; l++) {
-            // try {} catch{} block added by erikvold VKI
-            try {
-                //protocol, host, hostname, port, pathname, search, hash
-                if (hrefs[l].protocol == "mailto:") {
-                    startListening(hrefs[l], "mousedown", trackMailto);
-                } else if (hrefs[l].protocol == "tel:") {
-                    startListening(hrefs[l], "mousedown", trackTelto);
-                } else if (hrefs[l].hostname == location.host) {
-                    var path = hrefs[l].pathname + hrefs[l].search;
-                    var isDoc = path.match(/\.(?:doc|docx|eps|jpg|png|svg|xls|xlsx|ppt|pptx|pdf|zip|txt|vsd|vxd|js|css|rar|exe|wma|mov|avi|wmv|mp3)($|\&|\?)/);
-                    if (isDoc) {
-                        startListening(hrefs[l], "mousedown", trackExternalLinks);
-                    }
-                } else if (!hrefs[l].href.match(/^javascript:/)) {
-                    startListening(hrefs[l], "mousedown", trackExternalLinks);
-                }
-            }
-            catch (e) {
-                continue;
-            }
-        }
-    }
+	if (document.getElementsByTagName) {
+		// Initialize external link handlers
+		var hrefs = document.getElementsByTagName("a");
+		for (var l = 0; l < hrefs.length; l++) {
+			// try {} catch{} block added by erikvold VKI
+			try{
+				//protocol, host, hostname, port, pathname, search, hash
+				if (hrefs[l].protocol == "mailto:") {
+					startListening(hrefs[l],"mousedown",trackMailto);
+				} else if (hrefs[l].protocol == "tel:") {
+					startListening(hrefs[l],"mousedown",trackTelto);
+				} else if (hrefs[l].hostname == location.host) {
+					var path = hrefs[l].pathname + hrefs[l].search;
+					var isDoc = path.match(/\.(?:doc|docx|eps|jpg|png|svg|xls|xlsx|ppt|pptx|pdf|zip|txt|vsd|vxd|js|css|rar|exe|wma|mov|avi|wmv|mp3)($|\&|\?)/);
+					if (isDoc) {
+						startListening(hrefs[l],"mousedown",trackExternalLinks);
+					}
+				} else if (!hrefs[l].href.match(/^javascript:/)) {
+					startListening(hrefs[l],"mousedown",trackExternalLinks);
+				}
+			}
+			catch(e){
+				continue;
+			}
+		}
+	}
 }
 
-function startListening(obj, evnt, func) {
-    if (obj.addEventListener) {
-        obj.addEventListener(evnt, func, false);
-    } else if (obj.attachEvent) {
-        obj.attachEvent("on" + evnt, func);
-    }
+function startListening (obj,evnt,func) {
+	if (obj.addEventListener) {
+		obj.addEventListener(evnt,func,false);
+	} else if (obj.attachEvent) {
+		obj.attachEvent("on" + evnt,func);
+	}
 }
 
-function trackMailto(evnt) {
-    var href = (evnt.srcElement) ? evnt.srcElement.href : this.href;
-    var mailto = "/mailto/" + href.substring(7);
-    _gaq.push(['_trackPageview', mailto]);
-    _gaq.push(['b._trackPageview', mailto]);
+function trackMailto (evnt) {
+	var href = (evnt.srcElement) ? evnt.srcElement.href : this.href;
+	var mailto = "/mailto/" + href.substring(7);
+	_gaq.push(['_trackPageview', mailto]);
+	_gaq.push(['b._trackPageview', mailto]);
 }
 
-function trackTelto(evnt) {
-    var href = (evnt.srcElement) ? evnt.srcElement.href : this.href;
-    var telto = "/telto/" + href.substring(4);
-    _gaq.push(['_trackPageview', telto]);
-    _gaq.push(['b._trackPageview', telto]);
+function trackTelto (evnt) {
+	var href = (evnt.srcElement) ? evnt.srcElement.href : this.href;
+	var telto = "/telto/" + href.substring(4);
+	_gaq.push(['_trackPageview', telto]);
+	_gaq.push(['b._trackPageview', telto]);
 }
 
-function trackExternalLinks(evnt) {
-    var e = (evnt.srcElement) ? evnt.srcElement : this;
-    while (e.tagName != "A") {
-        e = e.parentNode;
-    }
-    var lnk = (e.pathname.charAt(0) == "/") ? e.pathname : "/" + e.pathname;
-    if (e.search && e.pathname.indexOf(e.search) == -1) lnk += e.search;
-    if (e.hostname != location.host) lnk = "/external/" + e.hostname + lnk;
-    _gaq.push(['_trackPageview', lnk]);
-    _gaq.push(['b._trackPageview', lnk]);
+function trackExternalLinks (evnt) {
+	var e = (evnt.srcElement) ? evnt.srcElement : this;
+	while (e.tagName != "A") {
+		e = e.parentNode;
+	}
+	var lnk = (e.pathname.charAt(0) == "/") ? e.pathname : "/" + e.pathname;
+	if (e.search && e.pathname.indexOf(e.search) == -1) lnk += e.search;
+	if (e.hostname != location.host) lnk = "/external/" + e.hostname + lnk;
+	_gaq.push(['_trackPageview', lnk]);
+	_gaq.push(['b._trackPageview', lnk]);
 }
 
 // End gatag.js
@@ -12619,13 +12619,13 @@ $.extend($.expr[':'], {
    PANELS - /source/js/cagov/panel.js
 ----------------------------------------- */
 
-$(document).ready(function () {
+$(document).ready(function(){ 
     // Finds the first panel in the sidebar
     // Adds the "first" class
     $(".main-secondary .panel").first().addClass("first");
-
+       
     // Add a hook to the standout panel for adding a triangle
-    $(".panel.highlight").find(".panel-heading").prepend("<span class='triangle'></span>");
+    $(".panel.highlight").find(".panel-heading").prepend( "<span class='triangle'></span>" );
 });
 
 /* -----------------------------------------
@@ -12635,7 +12635,7 @@ $(document).ready(function () {
 $(document).ready(function () {
     var $searchContainer = $("#head-search");
     var $searchText = $searchContainer.find(".search-textfield");
-    var $resultsContainer = $('.search-results-container');
+    var $resultsContainer =$('.search-results-container');
 
     var $body = $("body");
     var $specialIcon =
@@ -12686,22 +12686,22 @@ $(document).ready(function () {
         // unitll the window has scrolled, and it will keep removing the ".active" class. After that we can apply the active
         // class.
 
-        //------------------------------------------------------------- v5 ----------------------------------------- *Changes to remove .primary body class dependency for featured-search behaviour 
+		//------------------------------------------------------------- v5 ----------------------------------------- *Changes to remove .primary body class dependency for featured-search behaviour 
+		
+		if ( $( "#head-search" ).is( ".featured-search" ) ) {
+		//-------------- v5 *Added if statement
+        window.setTimeout(function() {
+            $('body:not(.primary) .search-container').addClass('active');
+        } ,401);
+		
+		}else{
+		
+		 window.setTimeout(function() {
+            $('.search-container').addClass('active');
+        } ,401);	
 
-        if ($("#head-search").is(".featured-search")) {
-            //-------------- v5 *Added if statement
-            window.setTimeout(function () {
-                $('body:not(.primary) .search-container').addClass('active');
-            }, 401);
-
-        } else {
-
-            window.setTimeout(function () {
-                $('.search-container').addClass('active');
-            }, 401);
-
-        }
-
+		}
+		
     });
 
     // SEE navitgation.js for mobile click handlers
@@ -12755,7 +12755,7 @@ $(document).ready(function () {
     // Tabs to accordion
     // https://github.com/openam/bootstrap-responsive-tabs
     fakewaffle.responsiveTabs(['xs', 'sm']);
-
+    
     // https://github.com/jsliang/eqHeight.coffee
     // Generic EQ Heights for top level children
     // Example: Use on .group to effect columns
@@ -12765,18 +12765,18 @@ $(document).ready(function () {
 /* -----------------------------------------
    GALLERY - /source/js/cagov/gallery.js
 ----------------------------------------- */
-
-$(document).ready(function () {
-    // Requires fancyBox v2.1.5
+    
+$(document).ready(function(){
+	// Requires fancyBox v2.1.5
     // Enable lightbox functionality
-    $('.gallery .item a, .carousel-gallery .item a, a.gallery-item').fancybox({ groupAttr: "data-gallery" });
-
+    $('.gallery .item a, .carousel-gallery .item a, a.gallery-item').fancybox({groupAttr: "data-gallery"});
+    
     //   EQ Heights for Gallery Items
     $(".gallery").eqHeight(".item");
-
+    
     // Trick eqHeights into running as tabs are focused so image galleries in tabs get height applied.
     // eqHeight plugin would not run using normal selection methods. Triggering resize event to trick eqHeight to run on tab focus
-    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+    $('a[data-toggle="tab"]').on('shown.bs.tab', function (e){
         window.dispatchEvent(new Event('resize'));
     });
 });
@@ -12784,7 +12784,7 @@ $(document).ready(function () {
    PROFILE BANNERS
 ----------------------------------------- */
 
-$(document).ready(function () {
+$(document).ready(function(){
     // If using profile banners side by side in a .half this equal heights function will ensure they are the same height.
     $(".main-secondary").eqHeight(".profile-banner > .inner");
 });
@@ -12824,7 +12824,7 @@ $(document).ready(function () {
                         ? MAXHEIGHT
                         : height;
                     // fill up the remaining heaight of this device
-                    headerSlider.css({ 'height': height });
+                    headerSlider.css({'height': height});
                 }, 0)
 
                 var $this = $(this);
@@ -12854,25 +12854,22 @@ $(document).ready(function () {
 
                 // Add pause and play buttons
                 var owlBannerControl = $('<div class="banner-play-pause"><div class="banner-control"><span class="play ca-gov-icon-carousel-play" aria-hidden="true"></span><span class="pause ca-gov-icon-carousel-pause" aria-hidden="true"></span></div></div>');
-                $this.append(owlBannerControl);
-                var playControl = owlBannerControl.find('.play').hide();
-                var pauseControl = owlBannerControl.find('.pause');
-                playControl.on('click', function () {
-                    $(this).hide(); $(this).parent().removeClass('active');
-                    pauseControl.show(); $this.trigger('play.owl.autoplay', [settings.delay]);
-                    $this.owlCarousel('next'); // Manually play next since autoplay waits for delay
+                $this.append(owlBannerControl); 
+                var playControl = owlBannerControl.find('.play').hide(); 
+                var pauseControl = owlBannerControl.find('.pause'); 
+                playControl.on('click', function() {
+                $(this).hide();   $(this).parent().removeClass('active');
+                pauseControl.show();   $this.trigger('play.owl.autoplay', [settings.delay]);
+                $this.owlCarousel('next'); // Manually play next since autoplay waits for delay
                 });
-
-                pauseControl.on('click', function () {
-                    $(this).hide();
-                    $(this).parent().addClass('active'); playControl.show();
-                    $this.trigger('stop.owl.autoplay');
-                });
-
+                
+                pauseControl.on('click', function() {   $(this).hide();
+                $(this).parent().addClass('active');   playControl.show();
+                $this.trigger('stop.owl.autoplay'); });
+                
                 // Number the items in .banner-pager 
-                var dots = $('.banner-pager .banner-control'); dots.each(function () {
-                    $(this).find('span').append($(this).index() + 1);
-                });
+                var dots = $('.banner-pager .banner-control'); dots.each(function(){
+                $(this).find('span').append($(this).index() + 1); });
             });
         }
     }(jQuery));
@@ -13007,13 +13004,13 @@ function initContent() {
     })
 }
 
-(function ($) {
+(function($) {
 
-    $.fn.initCAVideo = function (bool) {
+    $.fn.initCAVideo = function(bool) {
 
 
         // Iterate over each object in collection
-        return this.each(function () {
+        return this.each( function() {
 
             var carousel = $(this);
             var didSet = carousel.attr("data-loaded");
@@ -13022,131 +13019,131 @@ function initContent() {
                 return;
             }
             carousel.attr("data-loaded", "true");
-            // get first video
-            var vidHref = carousel.find('.item a').first().attr('href') || "";
-            var vidID = vidHref.split("?v=").pop();
+                // get first video
+                var vidHref = carousel.find('.item a').first().attr('href') || "";
+                var vidID = vidHref.split("?v=").pop();
 
-            var mainIndex = 0;
-
-
-            var length = carousel.find('.item').length;
-
-            // Video  Slider
-            carousel.owlCarousel({
-                items: 1,
-                loop: false,
-                nav: true,
-                lazyLoad: false,
-                video: true,
-                navText: [
-                    '<span class="ca-gov-icon-arrow-prev" aria-hidden="true"></span>', '<span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>'
-                ],
-                dots: false
-            });
-
-            carousel.on('translated.owl.carousel', function (event) {
-
-                // get current video id
-                vidID = carousel.find('.owl-item.active')
-                          .attr('data-video').split(/\?v=|\/v\//).pop();
-                setCurrentSubVideo();
-
-                mainIndex = event.item.index;
-                // show the item in view
-                submenu.trigger('to.owl.carousel', [mainIndex, 300, true])
-            });
+                var mainIndex = 0;
 
 
-            //  create the proper video play icon for each video image preview
-            carousel.find('.owl-video-play-icon').append($('<span class="ca-gov-icon-play" />'));
+                var length = carousel.find('.item').length;
 
-            // create the overlay for each video image preview
-            carousel.find('.owl-video-tn').after($('<div />').addClass('item-overlay'));
-
-            // the submenu lives as a sibling to the carousel.
-            var submenu = $('<div></div>').insertAfter(carousel);
-            submenu.addClass('carousel owl-carousel carousel-video-submenu');
-
-            // create the sub menu for the videos
-            var items = carousel.find('a.owl-video');
-            items.each(function (index) {
-                // get this slide and its video url
-                var oldItem = $(this);
-                var href = oldItem.attr('href');
-
-                // attach the triggers for each thumbnail
-                var item = $('<div/>').addClass('item-thumbnail');
-                item.on('click', function () {
-                    //  force the main carousel to jump to the requested video
-                    carousel.trigger('to.owl.carousel', [
-                        index % length,
-                        300,
-                        true
-                    ]);
-
-                    submenu.find('.watching').removeClass('watching');
-                    $(this).parents('.owl-item').addClass('watching');
-
-                    //  start playing immediately
-                    carousel.find(".active .owl-video-play-icon").trigger("click");
+                // Video  Slider
+                carousel.owlCarousel({
+                    items: 1,
+                    loop: false,
+                    nav: true,
+                    lazyLoad: false,
+                    video: true,
+                    navText: [
+                        '<span class="ca-gov-icon-arrow-prev" aria-hidden="true"></span>', '<span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>'
+                    ],
+                    dots: false
                 });
 
-                // thumbnail related
-                var regex = new RegExp('ab+c', 'i');
-                var youtubeID = href.split(/\?v=|\/v\//).pop();
-                var youtubeThumb = 'http://img.youtube.com/vi/' + youtubeID + '/0.jpg';
-                var thumbnail = $('<img />').attr('src', youtubeThumb);
+                carousel.on('translated.owl.carousel', function(event) {
 
-                // overlay related
-                var overlay = $('<div />').addClass('item-overlay');
-                overlay.append($('<span class="ca-gov-icon-play" />'))
+                  // get current video id
+                  vidID = carousel.find('.owl-item.active')
+                            .attr('data-video').split(/\?v=|\/v\//).pop();
+                    setCurrentSubVideo();
 
-                // Append it into the DOM
-                item.append(thumbnail).append(overlay);
-                submenu.append(item);
-            });
-
-            submenu = carousel.next();
-
-            submenu.on('initialized.owl.carousel', function () {
-                setCurrentSubVideo();
-            });
-
-            // have owlCarousel init this submenu
-            submenu.owlCarousel({
-                items: 4,
-                loop: false,
-                nav: true,
-                margin: 20,
-                dots: false,
-                navText: ['<span class="ca-gov-icon-arrow-prev" aria-hidden="true"></span>', '<span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>']
-            });
+                  mainIndex = event.item.index;
+                    // show the item in view
+                    submenu.trigger('to.owl.carousel', [ mainIndex, 300, true ] )
+             });
 
 
-            submenu.on('changed.owl.carousel', function () {
+                //  create the proper video play icon for each video image preview
+                carousel.find('.owl-video-play-icon').append($('<span class="ca-gov-icon-play" />'));
+
+                // create the overlay for each video image preview
+                carousel.find('.owl-video-tn').after($('<div />').addClass('item-overlay'));
+
+                // the submenu lives as a sibling to the carousel.
+                var submenu = $('<div></div>').insertAfter(carousel);
+                submenu.addClass('carousel owl-carousel carousel-video-submenu');
+
+                // create the sub menu for the videos
+                var items = carousel.find('a.owl-video');
+                items.each(function (index) {
+                    // get this slide and its video url
+                    var oldItem = $(this);
+                    var href = oldItem.attr('href');
+
+                    // attach the triggers for each thumbnail
+                    var item = $('<div/>').addClass('item-thumbnail');
+                    item.on('click', function () {
+                        //  force the main carousel to jump to the requested video
+                        carousel.trigger('to.owl.carousel', [
+                            index  % length,
+                            300,
+                            true
+                        ]);
+
+                        submenu.find('.watching').removeClass('watching');
+                        $(this).parents('.owl-item').addClass('watching');
+
+                        //  start playing immediately
+                        carousel.find(".active .owl-video-play-icon").trigger("click");
+                    });
+
+                    // thumbnail related
+                    var regex = new RegExp('ab+c', 'i');
+                    var youtubeID = href.split(/\?v=|\/v\//).pop();
+                    var youtubeThumb = 'http://img.youtube.com/vi/' + youtubeID + '/0.jpg';
+                    var thumbnail = $('<img />').attr('src', youtubeThumb);
+
+                    // overlay related
+                    var overlay = $('<div />').addClass('item-overlay');
+                    overlay.append($('<span class="ca-gov-icon-play" />'))
+
+                    // Append it into the DOM
+                    item.append(thumbnail).append(overlay);
+                    submenu.append(item);
+                });
+
+                submenu = carousel.next();
+
+                  submenu.on('initialized.owl.carousel', function() {
+                    setCurrentSubVideo();
+                  });
+
+                // have owlCarousel init this submenu
+                submenu.owlCarousel({
+                    items: 4,
+                    loop: false,
+                    nav: true,
+                    margin: 20,
+                    dots: false,
+                    navText: ['<span class="ca-gov-icon-arrow-prev" aria-hidden="true"></span>', '<span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>']
+                });
+
+
+              submenu.on('changed.owl.carousel', function() {
                 setTimeout(setCurrentSubVideo, 50);
-            });
+              });
 
-            function setCurrentSubVideo() {
+              function setCurrentSubVideo() {
                 // remove old watched item
                 submenu.find('.watching').removeClass('watching');
 
                 submenu.find('img[src*="' + vidID + '"]').parents('.owl-item').addClass('watching');
 
 
-            }
+              }
 
         });
     }
 }(jQuery));
 
 // EQ Heights for Job Wells
-$(document).ready(function () {
-    $(".job-detail").eqHeight(".well");
+$(document).ready(function() {
+   $(".job-detail").eqHeight(".well");
 });
 // EQ Heights for Map & Photo
-$(document).ready(function () {
-    $(".location.full").eqHeight(".photo, .map");
+$(document).ready(function() {
+   $(".location.full").eqHeight(".photo, .map");
 });
 /* -----------------------------------------
    SOCIAL SHARER
@@ -13154,51 +13151,51 @@ $(document).ready(function () {
    /source/js/cagov/socialsharer.js
 ----------------------------------------- */
 
-$(document).ready(function () {
+$(document).ready(function(){
     var docTitle = sanitize(document.title);
     var docURL = window.location.href;
     docURL = encodeURIComponent(sanitize(docURL));
 
     // TODO: flickr, linkedin, instagram, pinterest, vimeo, youtube
 
-    $(".ca-gov-icon-share-facebook").on('click', function (e) {
-        PopupCentered('https://www.facebook.com/sharer/sharer.php?u=' + docURL + '&display=popup', 'socialsharer', '658', '450')
+    $(".ca-gov-icon-share-facebook").on('click', function(e) {
+      PopupCentered('https://www.facebook.com/sharer/sharer.php?u=' + docURL + '&display=popup','socialsharer','658','450')
     });
 
-    $(".ca-gov-icon-share-twitter").on('click', function (e) {
-        PopupCentered('https://twitter.com/intent/tweet?text=' + docTitle + '&url=' + docURL, 'socialsharer', '568', '531')
+    $(".ca-gov-icon-share-twitter").on('click', function(e) {
+      PopupCentered('https://twitter.com/intent/tweet?text=' + docTitle + '&url=' + docURL,'socialsharer','568','531')
     });
 
-    $(".ca-gov-icon-share-googleplus").on('click', function (e) {
-        PopupCentered('https://plus.google.com/share?url=' + docURL, 'socialsharer', '550', '552')
+    $(".ca-gov-icon-share-googleplus").on('click', function(e) {
+      PopupCentered('https://plus.google.com/share?url=' + docURL,'socialsharer','550','552')
     });
 
-    $(".ca-gov-icon-share-email").attr('href', "mailto:?subject=" + docTitle + "&body=%0a" + docURL + "%0a%0a");
+    $(".ca-gov-icon-share-email").attr('href',  "mailto:?subject=" + docTitle + "&body=%0a" + docURL + "%0a%0a");
 
-    function sanitize(sText) {
-        // Remove html tags from a string
-        var re = /<\S[^>]*>/g;
-        sText = sText.replace(re, " ");
-        return sText;
-    }
+function sanitize(sText) {
+  // Remove html tags from a string
+  var re = /<\S[^>]*>/g;
+  sText = sText.replace(re, " ");
+  return sText;
+}
 
 
-    // Display a popup window centered over the parent window. Works in all browsers
-    // except Opera with multiple displays. Opera displays the popup on the primary
-    // display only.
-    function PopupCentered(url, popupName, popupWidth, popupHeight) {
-        // screenX/Y for IE9+ FF Op Chrome, screenLeft/Top for IE7 IE8 Chrome, left/top for old FF
-        var parentLeft = window.screenX ? window.screenX : window.screenLeft ? window.screenLeft : screen.left ? screen.left : 0;
-        var parentTop = window.screenY ? window.screenY : window.screenTop ? window.screenTop : screen.top ? screen.top : 0;
+// Display a popup window centered over the parent window. Works in all browsers
+// except Opera with multiple displays. Opera displays the popup on the primary
+// display only.
+function PopupCentered(url, popupName, popupWidth, popupHeight) {
+  // screenX/Y for IE9+ FF Op Chrome, screenLeft/Top for IE7 IE8 Chrome, left/top for old FF
+  var parentLeft = window.screenX ? window.screenX : window.screenLeft ? window.screenLeft : screen.left ? screen.left : 0;
+  var parentTop = window.screenY ? window.screenY : window.screenTop ? window.screenTop : screen.top ? screen.top : 0;
 
-        var parentWidth = window.innerWidth ? window.innerWidth : document.documentElement.clientWidth ? document.documentElement.clientWidth : screen.width;
-        var parentHeight = window.innerHeight ? window.innerHeight : document.documentElement.clientHeight ? document.documentElement.clientHeight : screen.height;
+  var parentWidth = window.innerWidth ? window.innerWidth : document.documentElement.clientWidth ? document.documentElement.clientWidth : screen.width;
+  var parentHeight = window.innerHeight ? window.innerHeight : document.documentElement.clientHeight ? document.documentElement.clientHeight : screen.height;
 
-        var popupLeft = (parentWidth / 2) - (popupWidth / 2) + parentLeft;
-        var popupTop = (parentHeight / 2) - (popupHeight / 2) + parentTop;
+  var popupLeft = (parentWidth / 2) - (popupWidth / 2) + parentLeft;
+  var popupTop = (parentHeight / 2) - (popupHeight / 2) + parentTop;
 
-        window.open(url, popupName, 'scrollbars=yes, width=' + popupWidth + ', height=' + popupHeight + ', left=' + popupLeft + ', top=' + popupTop);
-    }
+  window.open(url, popupName, 'scrollbars=yes, width=' + popupWidth + ', height=' + popupHeight + ', left=' + popupLeft + ', top=' + popupTop);
+}
 });
 
 /* -----------------------------------------
@@ -13208,48 +13205,49 @@ $(document).ready(function () {
 // This function populates the breadcrumb section of the page.
 // Adapted from http://webtools.ca.gov/tools/design-enhancements/breadcrumbs/ to use jQuery
 
-function breadcrumbs() {
-    if ($(".breadcrumb.dynamic")[0]) { // Make sure browser supports getElementById and breadcrumb_dynamic exists
-        var wrkLocation = location.href;
-        var wrkLength = wrkLocation.indexOf("#");  // Find the begining of any anchor reference
-        if (wrkLength != -1) {
-            wrkLocation = wrkLocation.substr(0, wrkLength);  // Remove the anchor reference
-        }
-        var wrkLength = wrkLocation.indexOf("?");  // Find the begining of the query string
-        if (wrkLength != -1) {
-            wrkLocation = wrkLocation.substr(0, wrkLength);  // Remove the query string
-        }
+function breadcrumbs()
+{
+	if ( $(".breadcrumb.dynamic")[0] ) { // Make sure browser supports getElementById and breadcrumb_dynamic exists
+		var wrkLocation = location.href;
+		var wrkLength = wrkLocation.indexOf("#");  // Find the begining of any anchor reference
+		if (wrkLength != -1) {
+			wrkLocation = wrkLocation.substr(0,wrkLength);  // Remove the anchor reference
+		}	
+		var wrkLength = wrkLocation.indexOf("?");  // Find the begining of the query string
+		if (wrkLength != -1) {
+			wrkLocation = wrkLocation.substr(0,wrkLength);  // Remove the query string
+		}
 
-        wrkLocation = unescape(wrkLocation);
+		wrkLocation = unescape(wrkLocation);
 
-        //var re = /<\S[^>]*>/g; // Remove html tags from a string
-        var re = /<.*/g; // remove < and anything after
-        wrkLocation = wrkLocation.replace(re, "");
+		//var re = /<\S[^>]*>/g; // Remove html tags from a string
+		var re = /<.*/g; // remove < and anything after
+		wrkLocation = wrkLocation.replace(re, "");
 
-        var arrURL = wrkLocation.split("/"); // Array containing the current location, split at the slashes
-        var output = '<li><a href="/">Home</a></li>'; // The string which will be output to the browser, starts with a link to the home page
-        var path = '/'; // Link for the crumbs
+		var arrURL=wrkLocation.split("/"); // Array containing the current location, split at the slashes
+		var output='<li><a href="/">Home</a></li>'; // The string which will be output to the browser, starts with a link to the home page
+		var path = '/'; // Link for the crumbs
 
-        // If last item is blank or index.* or default.*, remove it
-        if (arrURL[arrURL.length - 1] == '' || arrURL[arrURL.length - 1].match(/^index\.|^default\./i)) {
-            arrURL.length--;
-        }
+		// If last item is blank or index.* or default.*, remove it
+		if (arrURL[arrURL.length-1] == '' || arrURL[arrURL.length-1].match(/^index\.|^default\./i) ) {
+			arrURL.length--;
+		}
 
-        if (arrURL.length > 3) {
-            for (counter = 3; counter < arrURL.length - 1; counter++) {  // Loop to display the links
-                path += arrURL[counter] + '/';  // always end links to folder with '/' 
-                output += '<li><a href="' + path + '">' + (arrURL[counter].replace(/(_|-)/g, ' ')) + '</a></li>';
-            }
+		if (arrURL.length > 3) {
+			for (counter = 3;counter < arrURL.length-1;counter++) {  // Loop to display the links
+				path += arrURL[counter] + '/';  // always end links to folder with '/' 
+				output += '<li><a href="' + path + '">' + (arrURL[counter].replace(/(_|-)/g,' ')) + '</a></li>';
+			}
 
-            // Adds a class of active to the current page
-            output += '<li class="active">' + (arrURL[arrURL.length - 1].replace(/(_|-)/g, ' ').replace(/\.\w{3,5}$/, '')) + '</li>';
-        }
+			// Adds a class of active to the current page
+			output += '<li class="active">' + (arrURL[arrURL.length-1].replace(/(_|-)/g,' ').replace(/\.\w{3,5}$/,'')) + '</li>';
+		}
 
-        $(".breadcrumb.dynamic").html(output);  // Display the breadcrumbs
-    }
+		$(".breadcrumb.dynamic").html(output);  // Display the breadcrumbs
+	}
 }
 
-$(document).ready(function () {
+$(document).ready(function(){
     breadcrumbs();
 });
 
@@ -13567,7 +13565,7 @@ function initCountUp() {
 
     // prepare the dom
     counter.text('0');
-    counter.css({ 'visibility': 'visible' });
+    counter.css({'visibility': 'visible'});
 
 
 
@@ -13610,9 +13608,9 @@ function initCountUp() {
 
 // polyfill for ie8
 if (!String.prototype.trim) {
-    String.prototype.trim = function () {
-        return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
-    };
+  String.prototype.trim = function () {
+    return this.replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+  };
 }
 
 /* -----------------------------------------
@@ -13621,8 +13619,8 @@ if (!String.prototype.trim) {
 //------------------------------------------------------------- v5 ----------------------------------------- * need to consolidate .header-single-banner with header-large-banner,
 $(document).ready(function () {
     var $headerImage = $('.header-single-banner, .header-large-banner, .header-primary-banner');
-    var $headerLarge = $('.header-large-banner');
-    var $primaryBanner = $('.header-primary-banner');
+	var $headerLarge = $('.header-large-banner');
+	var $primaryBanner = $('.header-primary-banner');
     var windowHeight = $(window).height();
     var $header = $('header');
 
@@ -13632,12 +13630,12 @@ $(document).ready(function () {
 
     var $headSearch = $('#head-search');
 
-    // Beta 5 Changes please incorporate into source files
+// Beta 5 Changes please incorporate into source files
 
-    setTimeout(function () {
-        $askGroup.addClass('in')
-        $headSearch.addClass('in')
-    }, 150)
+setTimeout(function(){
+  $askGroup.addClass('in')
+  $headSearch.addClass('in')
+}, 150)
 
     // setting up global variables for header functions
     window.headerVars = {
@@ -13648,36 +13646,36 @@ $(document).ready(function () {
             if ($headerImage.length == 0) {
                 return
             }
-
+			
             var height = windowHeight;
             height = Math.max(Math.min(height, headerVars.MAXHEIGHT), headerVars.MINHEIGHT);
+			
+			var headerTop = $headerImage.offset().top;
+			
+            $headerImage.css({'height': height - $header.height()});
+            headerImageHeight = $headerImage.height();		
+							
+			$headerLarge.css({'height': height - headerTop});
+            headerImageHeight = $headerLarge.height();		
+			
+			$primaryBanner.css({'height': 450 });
 
-            var headerTop = $headerImage.offset().top;
+// Beta v5 Changes please incorporate into source files	
 
-            $headerImage.css({ 'height': height - $header.height() });
-            headerImageHeight = $headerImage.height();
-
-            $headerLarge.css({ 'height': height - headerTop });
-            headerImageHeight = $headerLarge.height();
-
-            $primaryBanner.css({ 'height': 450 });
-
-            // Beta v5 Changes please incorporate into source files	
-
-
+	
         }
     };
 
     headerVars.setHeaderImageHeight();
-
+	
 
 
     // Take header image and place it on the ask group div for mobile
 
     var bgImage = $headerImage.css('background-image');
-    var askGroup = $('.ask-group');
+        var askGroup = $('.ask-group');
 
-    askGroup.attr("style", "background-size: cover; background-repeat: no-repeat; background-image:" + bgImage)
+        askGroup.attr("style", "background-size: cover; background-repeat: no-repeat; background-image:" + bgImage)
 
 
 });
@@ -13695,7 +13693,7 @@ $(document).ready(function () {
     var askBarPadding = 10;
     // set up variables here for each maintenance in the future.
     var $header = $('header');
-    var $headerImage = $('.header-single-banner');
+    var $headerImage = $('.header-single-banner' );
 
     var $exploreMore = $('.explore-invite');
     var $globalHeader = $('.global-header');
@@ -13714,7 +13712,7 @@ $(document).ready(function () {
     var hideDistance = calcInputDifference();
 
     setAskBarTop();
-    $headSearch.bind("transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd", function () { setAskBarTop(); });
+    $headSearch.bind("transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd", function(){ setAskBarTop(); });
     function setAskBarTop() {
         window.setTimeout(function () {
             if ($headSearch.hasClass('active') || !$globalHeader.hasClass('fixed')) {
@@ -13810,7 +13808,7 @@ $(document).ready(function () {
             } else {
                 removeFixed();
             }
-            setAskBarTop();
+        setAskBarTop();
         });
     }
 
@@ -13956,38 +13954,38 @@ $(document).ready(function () {
             $headerImage.css({
                 height: height + headerHeight + leeway
             });
-            // take into account the fixed header -----------------------------------------------------v5 FIX---------------------------------
-
-        } else {
+// take into account the fixed header -----------------------------------------------------v5 FIX---------------------------------
+       	 	
+			}  else {
             // no header image, which means our main content needs to
-
-            $mainContent.css({
+		  						
+			$mainContent.css({
                 'padding-top': Math.max(headerHeight, 136)
+            })		
+			
+		
+		 	} if ($(".ask-group").length > 0) {
+				
+			$mainContent.css({
+            'padding-top': 0
             })
-
-
-        } if ($(".ask-group").length > 0) {
-
-            $mainContent.css({
-                'padding-top': 0
-            })
-
-            $('.header-slideshow-banner, .header-primary-banner').css({
-                'margin-top': 136
-
-            });
-
-
+			
+			 $('.header-slideshow-banner, .header-primary-banner').css({
+		     'margin-top': 136
+			 
+			 });
+													
+							
         }
     }
-    // take into account the fixed header -----------------------------------------------------v5 FIX---------------------------------
-
-
+ // take into account the fixed header -----------------------------------------------------v5 FIX---------------------------------
+ 
+ 
     // remove all inline styles from setting the fixed header
     function removeFixed() {
         $header.removeClass('fixed');
-        $headerImage.css({ 'top': '', 'margin-bottom': '' });
-        $mainContent.css({ 'padding-top': '' });
+        $headerImage.css({'top': '', 'margin-bottom': ''});
+        $mainContent.css({'padding-top': ''});
         $askGroupBar.css('top', '')
     }
 
@@ -14099,7 +14097,7 @@ function initPlotly(d3, Plotly) {
 
         $(window).resize(function () {
 
-            var gd3 = d3.select(container.get(0)).style({ height: getHeight() });
+            var gd3 = d3.select(container.get(0)).style({height: getHeight()});
             Plotly.Plots.resize(gd);
         });
 
@@ -14187,10 +14185,10 @@ function getConfig(d3, container, func) {
 
     if (xValues) {
         xValues = xValues.split('|').map(function (d) {
-            if (isNaN(parseFloat(d))) {
-                return d;
+            if(isNaN(parseFloat(d))) {
+              return d;
             }
-            return +d
+            return + d
         });
     } else {
         xValues = [];
@@ -14206,7 +14204,7 @@ function getConfig(d3, container, func) {
         case "bar":
             config[0].x = xValues
             config[0].y = yValues.map(function (d) {
-                return +d
+                return + d
             });
             break;
 
@@ -14253,7 +14251,7 @@ function getConfig(d3, container, func) {
 function initStats() {
     var container = $(this);
     var libs = ['d3'];
-    if ($('html').hasClass('ie8') || $('html').hasClass('ie7')) {
+    if ($('html').hasClass('ie8')|| $('html').hasClass('ie7') ) {
         return;
         //  TODO: Unsupport graphs fall back to something else
     }
@@ -14287,7 +14285,7 @@ function initStats() {
 
         var donutChart = new Donut(config);
 
-        donutChart.load({ data: 0 });
+        donutChart.load({data: 0});
 
         function sizeText() {
             var width = chart.get(0).clientWidth;
@@ -14327,7 +14325,7 @@ function initStats() {
                 }
                 config.data = data;
                 donutChart = new Donut(config);
-                donutChart.load({ data: data });
+                donutChart.load({data: data});
                 sizeText();
             }, 10)
 
@@ -14338,7 +14336,7 @@ function initStats() {
             // start when it appears at the bottom
             offset: '100%',
             handler: function () {
-                donutChart.load({ data: data })
+                donutChart.load({data: data})
             }
         });
     })
@@ -14432,7 +14430,7 @@ function initHalfDonut(d3) {
 
         // Compute the numeric values for each data element.
         var values = data.map(function (d, i) {
-            return +accessor.call(self, d, i);
+            return + accessor.call(self, d, i);
         });
 
         var sum = d3.sum(values),
@@ -14562,10 +14560,10 @@ function initHalfDonut(d3) {
 
     function removeArcTween(a, i, donut) {
         var emptyArc = {
-            startAngle: degToRad(donut.config.endAngle),
-            endAngle: degToRad(donut.config.endAngle),
-            value: 0
-        },
+                startAngle: degToRad(donut.config.endAngle),
+                endAngle: degToRad(donut.config.endAngle),
+                value: 0
+            },
             i = d3.interpolate(a, emptyArc);
         return function (t) {
             return donut.arc(i(t));
@@ -14621,44 +14619,44 @@ function initHalfDonut(d3) {
    /source/js/cagov/parallax.js
 ----------------------------------------- */
 
-(function ($) {
+(function($) {
 
-    $.fn.parallax = function (options) {
+    $.fn.parallax = function(options) {
 
         var windowHeight = $(window).height();
 
         // Establish default settings
         var settings = $.extend({
-            speed: 0.3
+            speed        : 0.3
         }, options);
 
         // Iterate over each object in collection
-        return this.each(function () {
+        return this.each( function() {
 
             // Save a reference to the element
             var $this = $(this);
 
-            // Init proper heights
-            var bg_height = ($(window).outerHeight() * settings.speed) + $this.innerHeight();
-            $this.css({ 'height': bg_height });
+              // Init proper heights
+              var bg_height = ($(window).outerHeight() * settings.speed) + $this.innerHeight();
+              $this.css( { 'height' : bg_height } );
 
             // Set up Scroll Handler
-            $(window).scroll(function () {
+            $(window).scroll(function() {
                 var element_top = $this.offset().top,
                     window_top = $(window).scrollTop(),
-                    y_pos = (((window_top + $(window).innerHeight()) - element_top) * settings.speed),
+                    y_pos = ( ( ( window_top + $(window).innerHeight() ) - element_top ) * settings.speed ),
                     main_position;
 
                 main_position = 'translate(0, ' + y_pos + 'px)';
 
-                $this.css({
-                    '-webkit-transform': main_position,
-                    '-moz-transform': main_position,
-                    '-ms-transform': main_position,
-                    'transform': main_position
-                });
+                $this.css( {
+                    '-webkit-transform' : main_position,
+                    '-moz-transform'    : main_position,
+                    '-ms-transform'     : main_position,
+                    'transform'         : main_position
+                } );
             });
-            // $(window).scroll();
+        // $(window).scroll();
 
         });
     }
@@ -14676,25 +14674,25 @@ $(document).ready(function () {
 
 
 function initAnimations() {
-    var $this = $(this);
-    var waypoint = new Waypoint({
-        element: $this.get(0),
-        // start when it appears at the bottom
-        offset: '95%',
-        handler: function () {
-            // get the class and animation name out of it
-            var animation = $this.attr("class").match(/animate-(\w+)\b/i)[1];
-            var toRemove = 'animate-' + animation;
-            var toAdd = 'animated ' + animation;
+  var $this = $(this);
+  var waypoint = new Waypoint({
+      element: $this.get(0),
+      // start when it appears at the bottom
+      offset: '95%',
+      handler: function () {
+          // get the class and animation name out of it
+          var animation = $this.attr("class").match(/animate-(\w+)\b/i)[1];
+          var toRemove = 'animate-' + animation;
+          var toAdd = 'animated ' + animation;
 
-            // update classes
-            $this.removeClass('animate-' + animation);
-            $this.addClass('animated ' + animation);
+          // update classes
+          $this.removeClass('animate-' + animation);
+          $this.addClass('animated ' + animation);
 
-            // stop firing again
-            this.disable();
-        }
-    })
+          // stop firing again
+          this.disable();
+      }
+  })
 }
 
 $(document).ready(function () {
@@ -14710,14 +14708,14 @@ $(document).ready(function () {
     $(".explore-invite").on('click', function (e) {
         e.preventDefault();
         var extraHeight = $('header.fixed').height();
-        $viewport.animate({
+         $viewport.animate({
             scrollTop: $(".main-primary").offset().top - extraHeight
         }, 2000);
 
         // Stop the animation if the user scrolls
-        $(document).one("scroll mousedown DOMMouseScroll mousewheel keyup touchstart", function (e) {
-            if (e.which > 0 || e.type === "mousedown" || e.type === "mousewheel" || e.type == 'touchstart') {
-                $viewport.stop();
+        $(document).one("scroll mousedown DOMMouseScroll mousewheel keyup touchstart", function(e){
+            if ( e.which > 0 || e.type === "mousedown" || e.type === "mousewheel"  || e.type == 'touchstart'){
+                 $viewport.stop();
             }
         });
     });
@@ -14725,23 +14723,23 @@ $(document).ready(function () {
 
 });
 
-(function ($) {
+(function($) {
 
-    $.fn.toggleMore = function (bool) {
+    $.fn.toggleMore = function(bool) {
 
-        /**
-         * Helper for setting required attrs and class
-         */
-        function expanded($this, bool) {
-            if (bool) {
-                $this.addClass('active').attr('aria-expanded', 'true');
-            } else {
-                $this.removeClass('active').attr('aria-expanded', 'false');
-            }
-        }
+      /**
+       * Helper for setting required attrs and class
+       */
+      function expanded($this, bool) {
+          if (bool) {
+              $this.addClass('active').attr('aria-expanded', 'true');
+          } else {
+              $this.removeClass('active').attr('aria-expanded', 'false');
+          }
+      }
 
         // Iterate over each object in collection
-        return this.each(function () {
+        return this.each( function() {
 
             // Save a reference to the element
 
@@ -14756,7 +14754,7 @@ $(document).ready(function () {
                     : expanded($this, false);
             }
 
-
+  
             $this.off("click.cagovmore");
             $this.on("click.cagovmore", function () {
                 $this.hasClass('active')
@@ -14773,7 +14771,7 @@ $(document).ready(function () {
 
 // TODO: readd this back in
 function makeBlur($el) {
-    $el.Vague({ intensity: 6 }).blur();
+    $el.Vague({intensity: 6}).blur();
 }
 
 
@@ -14786,19 +14784,19 @@ function initLoad() {
     makeBlur(moreContents);
     function loadMore(url) {
         $(moreContents).load(url, function (response, status, xhr) {
-            var linkHeader = xhr.getResponseHeader("Link");
-            if (isTest) {
-                return;
-            }
-            if ((status == "error" || linkHeader == null)) {
-                $moreBtn.animate({
-                    'opacity': 0,
-                    'height': 0
-                }, 300, 'linear');
-            } else {
-                htmlURL = linkHeader.match(/<(.*?)>/)[1];
-            }
-        });
+          var linkHeader = xhr.getResponseHeader("Link");
+          if(isTest) {
+            return;
+          }
+          if ((status == "error" || linkHeader == null)) {
+              $moreBtn.animate({
+                  'opacity': 0,
+                  'height': 0
+              }, 300, 'linear');
+          } else {
+              htmlURL = linkHeader.match(/<(.*?)>/)[1];
+          }
+      });
     }
 
 
@@ -14900,7 +14898,7 @@ $(document).ready(function () {
         $('html').css("font-size", fontSize + 'rem')
     } else {
         fontSize = 1;
-        $('html').css("font-size", fontSize + 'rem')
+        $('html').css("font-size", fontSize  + 'rem')
     }
 
     // init button styles for fonts
@@ -15055,18 +15053,18 @@ $(document).ready(function () {
 
         $("#locationSettings").collapse("hide");
         displayCities.html(city);
+            
+       $("[data-locations-landing],[data-locations]").first().loadMapThat();
 
-        $("[data-locations-landing],[data-locations]").first().loadMapThat();
 
-
-        $(".header-single-banner").each(function () {
+        $(".header-single-banner").each(function() {
             var imageAjax = $.get(window.__getImageByLocation);
-            imageAjax.done(function (image) {
+            imageAjax.done(function(image) {
                 var newBg = 'url("' + image + '")';
                 var oldBg = $(".header-single-banner").css('background-image');
                 if (newBg !== oldBg) {
-                    if ($(window).width() <= 767) {
-                        $(".ask-group").fadeOut('3000', function () {
+                    if($(window).width() <= 767) {
+                        $(".ask-group").fadeOut('3000', function() {
 
                             $(this).css('background-image', 'url(' + image + ')').fadeIn('3000');
 
@@ -15074,9 +15072,9 @@ $(document).ready(function () {
                         });
                         $(".header-single-banner").css('background-image', 'url(' + image + ')')
                     } else {
-                        $(".header-single-banner").fadeOut('3000', function () {
+                        $(".header-single-banner").fadeOut('3000', function() {
 
-                            var bgImg = $(this).css('background-image', 'url(' + image + ')').fadeIn('3000', function () {
+                            var bgImg = $(this).css('background-image', 'url(' + image + ')').fadeIn('3000', function(){
                                 $(this).css("display", '');
                             })
 
@@ -15117,10 +15115,10 @@ $(document).ready(function () {
 $('.ask-button').attr('tabindex', 0);
 // Close Ask menu when clicked anwyere outside
 $('body').on('click', function (e) {
-    try {
-        $('.ask-panel').collapse('hide');
-    } catch (e) {
-        // ask panel is wonky
-    }
+try {
+      $('.ask-panel').collapse('hide');
+} catch (e) {
+  // ask panel is wonky
+}
 
 });


### PR DESCRIPTION
The arrows for the `.list-standout` style are inserted as inline-block pseudo-elements. Since their `font-size` is set to `1.5em`, they increase the height of the line they're on, disrupting the vertical rhythm of the list.

I suggest removing the arrows from the flow of the document. In my suggestion, I have absolutely positioned them and adjusted the other styles accordingly.